### PR TITLE
chore: add repo linting baseline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+fail_fast: false
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        name: ruff lint
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.3.2
+    hooks:
+      - id: prettier
+        name: prettier (markdown/json/yaml)
+        types_or: ['markdown', 'json', 'yaml']
+        additional_dependencies: ['prettier@3.3.2']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,11 @@ repos:
         name: ruff lint
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.3.2
+  - repo: local
     hooks:
       - id: prettier
         name: prettier (markdown/json/yaml)
+        entry: prettier --write
+        language: node
         types_or: ['markdown', 'json', 'yaml']
         additional_dependencies: ['prettier@3.3.2']

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+.bmad-core/
+.bmad-infrastructure-devops/
+docs/adr/
+docs/architecture/
+docs/prd/
+docs/qa/
+docs/evidence/
+AGENTS.md
+compose.yaml

--- a/docs/brownfield-architecture.md
+++ b/docs/brownfield-architecture.md
@@ -1,20 +1,24 @@
 # mcp-farm Brownfield Architecture Document
 
 ## Introduction
+
 This document captures the current state of the mcp-farm repository with emphasis on the MVP defined in the PRD: securing the included sample MCP server with OAuth 2.1 behind Traefik/Keycloak and preferring Streamable‑HTTP transport (SSE as fallback). It is written to support AI agents implementing Epic 1.
 
 ### Document Scope
+
 Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401 hint, OAuth 2.1 + PKCE, JWKS validation, Traefik routing/TLS, Streamable‑HTTP preferred, SSE fallback).
 
 ### Change Log
-| Date       | Version | Description                                    | Author |
-|------------|---------|------------------------------------------------|--------|
+
+| Date       | Version | Description                                                  | Author |
+| ---------- | ------- | ------------------------------------------------------------ | ------ |
 | 2025-09-15 | 1.1     | ADRs accepted; elicitation applied; Ready for Implementation | Arch   |
-| 2025-09-15 | 1.0     | Initial brownfield analysis                    | Arch   |
+| 2025-09-15 | 1.0     | Initial brownfield analysis                                  | Arch   |
 
 ## Quick Reference – Key Files and Entry Points
 
 ### Critical Files
+
 - Main entry (sample MCP): `sample-deep-research-mcp/sample_mcp.py`
 - Data fixture: `sample-deep-research-mcp/records.json`
 - Python deps: `sample-deep-research-mcp/requirements.txt`
@@ -24,6 +28,7 @@ Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401
 - FastMCP reference repo: `fastmcp/` (source and docs for transports and server patterns)
 
 ### Enhancement Impact Areas (from PRD)
+
 - Add PRM endpoint: `/.well-known/oauth-protected-resource`
 - 401 responses include `WWW-Authenticate: Bearer resource_metadata="<PRM URL>"`
 - JWT validation against Keycloak JWKS; enforce `iss` and `aud`
@@ -34,20 +39,23 @@ Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401
 ## High‑Level Architecture
 
 ### Technical Summary (Current)
+
 - Single Python FastMCP server started via `FastMCP.run(transport="sse", host="127.0.0.1", port=8000)`.
 - No authentication/authorization; no PRM route; no JWT verification.
 - Transport: SSE only at present; Streamable‑HTTP not yet configured.
 - Execution is a single process intended for local development (binds to `127.0.0.1`).
 
 ### Actual Tech Stack
-| Category  | Technology | Version/Notes                    |
-|---------- |----------- |----------------------------------|
-| Language  | Python     | 3.x (CPython)
-| MCP SDK   | fastmcp    | `2.5.2` (from `requirements.txt`)
-| MCP Core  | mcp        | `1.9.2` (from `requirements.txt`)
-| Transport | SSE        | Default in `sample_mcp.py`
+
+| Category  | Technology | Version/Notes                     |
+| --------- | ---------- | --------------------------------- |
+| Language  | Python     | 3.x (CPython)                     |
+| MCP SDK   | fastmcp    | `2.5.2` (from `requirements.txt`) |
+| MCP Core  | mcp        | `1.9.2` (from `requirements.txt`) |
+| Transport | SSE        | Default in `sample_mcp.py`        |
 
 ### Repository Structure Reality Check
+
 - Root contains project docs and BMAD agent config.
 - Sample server resides in `sample-deep-research-mcp/` (no containerization files present here).
 - Docs include PRD and OAuth/Keycloak primers under `docs/`.
@@ -67,6 +75,7 @@ Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401
 ```
 
 ### Key Modules and Their Purpose
+
 - `sample_mcp.py`
   - `create_server()` builds a `FastMCP` named "Cupcake MCP" with two tools:
     - `search(query: str) -> SearchResultPage` (keyword search over `records.json`)
@@ -77,16 +86,19 @@ Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401
 ## Data Models and APIs
 
 ### Pydantic Models (tool schemas)
+
 - `SearchResult { id, title, text }`
 - `SearchResultPage { results: list[SearchResult] }`
 - `FetchResult { id, title, text, url?, metadata? }`
 
 ### MCP Transport Endpoints (Current)
+
 - SSE transport exposed by FastMCP runner on `http://127.0.0.1:8000` (per README).
 - No Streamable‑HTTP endpoint configured yet.
 - No PRM route; unauthenticated requests do not advertise PRM metadata.
 
 ## Technical Debt and Known Issues (Current)
+
 1. No OAuth 2.1 integration: missing PRM route and JWT validation.
 2. SSE‑only; Streamable‑HTTP not yet wired (required/preferred per PRD).
 3. Binds to `127.0.0.1` for local development; when containerized behind Traefik, the app must bind `0.0.0.0` so Traefik can reach it over the bridge network.
@@ -94,19 +106,22 @@ Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401
 5. No log redaction policy; risk of leaking sensitive headers if added later.
 
 ### Workarounds and Gotchas
+
 - Container networking: Inside containers, binding to 127.0.0.1 isolates the process from other containers. Bind `0.0.0.0` when running under Traefik; keep `127.0.0.1` only for local, non-container runs.
 - Tool schemas are embedded; any auth layer must not alter tool I/O contracts.
 
 ## Integration Points and External Dependencies (Planned per PRD)
 
 ### External Services
-| Service  | Purpose                | Integration Type | Notes                                 |
-|--------- |------------------------|------------------|---------------------------------------|
-| Keycloak | OAuth 2.1 IdP          | OIDC/JWKS        | Enforce `iss` and `aud` claims        |
-| Traefik  | TLS + routing + rewrites| Reverse proxy    | Labels for host routing, RFC 8414 shim |
-| ChatGPT  | MCP Developer‑mode     | Client           | Performs OAuth; streams tool calls     |
+
+| Service  | Purpose                  | Integration Type | Notes                                  |
+| -------- | ------------------------ | ---------------- | -------------------------------------- |
+| Keycloak | OAuth 2.1 IdP            | OIDC/JWKS        | Enforce `iss` and `aud` claims         |
+| Traefik  | TLS + routing + rewrites | Reverse proxy    | Labels for host routing, RFC 8414 shim |
+| ChatGPT  | MCP Developer‑mode       | Client           | Performs OAuth; streams tool calls     |
 
 ### Internal Integration Points
+
 - PRM route under `/.well-known/oauth-protected-resource` must be public.
 - Protected MCP endpoints must 401 with PRM hint when unauthenticated.
 - JWT validation occurs in‑app for MVP (no ForwardAuth); Traefik provides TLS and routing.
@@ -114,34 +129,41 @@ Focused on areas relevant to: Epic 1 “OAuth‑Secured Sample MCP” (PRM + 401
 ## Development and Deployment (Current Reality)
 
 ### Local Development Setup
+
 1. `cd sample-deep-research-mcp`
 2. `python -m venv .venv && source .venv/bin/activate`
 3. `pip install -r requirements.txt`
 4. `python sample_mcp.py` (starts SSE on `127.0.0.1:8000`)
 
 ### Build and Deployment Process
+
 - No Dockerfile/compose in this folder at present; Traefik labels and containerization to be added during Epic 1.
 
 ## Testing Reality
+
 - No test suite present for the sample server.
 - Validation for MVP to be provided as scripts/docs (PRM/AS/401 checks, Streamable‑HTTP round‑trip).
 
 ## If Enhancement PRD Provided – Impact Analysis
 
 ### Files That Will Need Modification
+
 - `sample-deep-research-mcp/sample_mcp.py`: add PRM route, 401 PRM hint behavior, JWT validation (JWKS), switch/add Streamable‑HTTP transport; use `0.0.0.0` bind in container, `127.0.0.1` for local dev.
 
 ### New Files/Modules Likely Needed
+
 - `docs/validation.md` (or similar) with curl examples for PRM/AS/401/stream tests.
 - Containerization (Dockerfile/compose) and Traefik labels (host routing, optional RFC 8414 path‑insert rewrites).
 - `.env.example` capturing `MCP_SERVER_URL`, `KC_ISSUER`, `MCP_AUDIENCE`.
 
 ### Integration Considerations
+
 - Ensure PRM is reachable unauthenticated through Traefik.
 - JWT validation must reject tokens with wrong `iss`/`aud`; accept one configured fallback audience if required by ChatGPT.
 - Prefer Streamable‑HTTP; keep SSE fallback for compatibility/testing.
 
 ## Appendix – Useful Commands
+
 ```bash
 # Local sample server
 python sample_mcp.py
@@ -155,28 +177,34 @@ curl -i  https://<mcp-host>/mcp/... # expect 401 with WWW-Authenticate PRM hint
 ## Operational Notes & Validation (Added)
 
 ### Networking Assumptions
+
 - Local: bind `127.0.0.1:8000`.
 - In container behind Traefik: bind `0.0.0.0:8000` so Traefik can connect via the bridge network.
 - Validate from Traefik:
   - `docker exec -it traefik sh -lc "apk add --no-cache curl >/dev/null 2>&1 || true; curl -i http://mcp:8000/healthz"` → expect 200.
 
 ### Transport Capability Check
+
 - Confirm Streamable‑HTTP support in FastMCP (see `fastmcp/` repo). If unavailable, satisfy Gate C with SSE for MVP and plan Streamable‑HTTP post‑MVP.
 
 ### PRM and 401 Ownership
+
 - Ensure app emits 401 with PRM hint:
   - `curl -i https://<mcp-host>/mcp/messages/ | sed -n '1,15p'` → expect `WWW-Authenticate: Bearer resource_metadata="https://<mcp-host>/.well-known/oauth-protected-resource"`.
 
 ### Audience Policy
+
 - Enforce `aud=MCP_SERVER_URL`. Optional fallback via `MCP_ALT_AUDIENCE`; log when fallback is used.
 
 ### Discovery Smoke Tests
+
 ```bash
 curl -sS https://<oauth-host>/.well-known/oauth-authorization-server/realms/<realm> | jq '.token_endpoint,.authorization_endpoint,.jwks_uri'
 curl -sS https://<oauth-host>/realms/<realm>/.well-known/openid-configuration | jq '.issuer,.jwks_uri'
 ```
 
 ### Streaming Acceptance
+
 - First chunk < ~2s and ≥10 chunks total through Traefik for Streamable‑HTTP (or equivalent SSE cadence).
 
 ## Reference Deployment — Docker + Traefik (Proposed)
@@ -184,6 +212,7 @@ curl -sS https://<oauth-host>/realms/<realm>/.well-known/openid-configuration | 
 This section provides a minimal, copy‑pasteable baseline for Epic 1. It is intentionally simple and label‑driven so it can be adapted per host.
 
 ### Dockerfile (sample‑deep‑research‑mcp)
+
 ```dockerfile
 # ./sample-deep-research-mcp/Dockerfile
 FROM python:3.11-slim
@@ -199,9 +228,10 @@ CMD ["python", "sample_mcp.py"]
 ```
 
 ### Compose with Traefik Labels
+
 ```yaml
 # ./compose.yaml (reference)
-version: "3.9"
+version: '3.9'
 services:
   traefik:
     image: traefik:v3.1
@@ -212,7 +242,7 @@ services:
       - --certificatesresolvers.dev.acme.tlschallenge=true
       - --certificatesresolvers.dev.acme.email=you@example.com
       - --certificatesresolvers.dev.acme.storage=/letsencrypt/acme.json
-    ports: ["80:80", "443:443"]
+    ports: ['80:80', '443:443']
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik_data:/letsencrypt
@@ -224,11 +254,11 @@ services:
       MCP_SERVER_URL: https://mcp.localhost
       KC_ISSUER: https://auth.localhost/realms/mcp
       MCP_AUDIENCE: https://mcp.localhost
-      MCP_ALT_AUDIENCE: ""  # optional fallback; leave empty by default
+      MCP_ALT_AUDIENCE: '' # optional fallback; leave empty by default
       BIND_HOST: 0.0.0.0
       BIND_PORT: 8000
       LOG_LEVEL: info
-    expose: ["8000"]
+    expose: ['8000']
     labels:
       - traefik.enable=true
       - traefik.http.routers.mcp.rule=Host(`mcp.localhost`)
@@ -242,12 +272,12 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:25.0
-    command: ["start"]
+    command: ['start']
     environment:
       KC_PROXY: edge
       KC_HOSTNAME: auth.localhost
-      KC_HTTP_ENABLED: "true"
-    expose: ["8080"]
+      KC_HTTP_ENABLED: 'true'
+    expose: ['8080']
     labels:
       - traefik.enable=true
       - traefik.http.routers.kc.rule=Host(`auth.localhost`)
@@ -268,24 +298,26 @@ volumes:
 ```
 
 Notes
+
 - For production, replace `mcp.localhost` and `auth.localhost` with real FQDNs and use a DNS‑validated resolver. The above is suitable for local testing with hosts entries.
 - The MCP container binds `0.0.0.0:8000` so Traefik can reach it. Local non‑container runs may keep `127.0.0.1`.
 
 ## Configuration — Environment Variables
 
-| Variable            | Purpose                                   | Example                          |
-|---------------------|-------------------------------------------|----------------------------------|
-| `MCP_SERVER_URL`    | Canonical external URL of MCP             | `https://mcp.localhost`          |
-| `KC_ISSUER`         | Keycloak Issuer (realm public URL)        | `https://auth.localhost/realms/mcp` |
-| `KC_JWKS_URI`       | Optional explicit JWKS URI                | `https://auth.localhost/realms/mcp/protocol/openid-connect/certs` |
-| `MCP_AUDIENCE`      | Expected `aud` claim                       | `https://mcp.localhost`          |
-| `MCP_ALT_AUDIENCE`  | Optional fallback audience                 | `` (empty)                       |
-| `BIND_HOST`         | Bind interface inside container            | `0.0.0.0`                        |
-| `BIND_PORT`         | Bind port                                  | `8000`                           |
-| `ALLOWED_ORIGINS`   | CORS allowlist if needed                   | `https://chat.openai.com`        |
-| `LOG_LEVEL`         | App log level                              | `info`                           |
+| Variable           | Purpose                            | Example                                                           |
+| ------------------ | ---------------------------------- | ----------------------------------------------------------------- |
+| `MCP_SERVER_URL`   | Canonical external URL of MCP      | `https://mcp.localhost`                                           |
+| `KC_ISSUER`        | Keycloak Issuer (realm public URL) | `https://auth.localhost/realms/mcp`                               |
+| `KC_JWKS_URI`      | Optional explicit JWKS URI         | `https://auth.localhost/realms/mcp/protocol/openid-connect/certs` |
+| `MCP_AUDIENCE`     | Expected `aud` claim               | `https://mcp.localhost`                                           |
+| `MCP_ALT_AUDIENCE` | Optional fallback audience         | `` (empty)                                                        |
+| `BIND_HOST`        | Bind interface inside container    | `0.0.0.0`                                                         |
+| `BIND_PORT`        | Bind port                          | `8000`                                                            |
+| `ALLOWED_ORIGINS`  | CORS allowlist if needed           | `https://chat.openai.com`                                         |
+| `LOG_LEVEL`        | App log level                      | `info`                                                            |
 
 Implementation Guidance
+
 - Validate envs at startup and emit a single structured line summarizing effective values (excluding secrets).
 - Do not log tokens or Authorization headers; ensure redaction in both success and error paths.
 
@@ -296,13 +328,12 @@ The PRD requires a PRM endpoint at `/.well-known/oauth-protected-resource`. The 
 ```json
 {
   "resource": "https://mcp.localhost",
-  "authorization_servers": [
-    "https://auth.localhost/realms/mcp"
-  ]
+  "authorization_servers": ["https://auth.localhost/realms/mcp"]
 }
 ```
 
 Notes
+
 - The exact metadata fields are validated via our acceptance script; the above is a minimal, practical payload for clients to discover the AS and correlate the resource.
 - Return `application/json; charset=utf-8` and cache for a short TTL (e.g., 60s) to allow config changes during bring‑up.
 
@@ -315,6 +346,7 @@ Notes
 - CORS: default deny; allow only known MCP client origins if required (ChatGPT typically does not need CORS for SSE/HTTP from server‑side).
 
 Rate Limiting & Request Limits
+
 - Traefik rate limit (per source IP): average 50 rps, burst 25 (tune with evidence).
 - Max body size: 2 MiB (Traefik middleware) for MCP endpoints.
 
@@ -325,6 +357,7 @@ Rate Limiting & Request Limits
 - Startup banner: dump effective transport(s) enabled and PRM URL.
 
 Monitoring (MVP)
+
 - Logs to stdout; container logs aggregated by platform.
 - Optional: enable Traefik Prometheus metrics; no app metrics for MVP.
 
@@ -343,6 +376,7 @@ Monitoring (MVP)
 - All above mapped to PRD Gates A–C.
 
 Accepted ADRs
+
 - 001 Prefer Streamable‑HTTP over SSE (keep SSE fallback) — Accepted (docs/adr/001-prefer-streamable-http-over-sse.md)
 - 002 In‑app JWT verification vs Traefik ForwardAuth — Accepted (docs/adr/002-in-app-jwt-vs-traefik-forwardauth.md)
 - 003 PRM at well‑known on MCP host — Accepted (docs/adr/003-prm-at-well-known-on-mcp-host.md)
@@ -360,6 +394,7 @@ Accepted ADRs
 7. S7: ChatGPT Developer‑mode onboarding + validation scripts; confirm custom connector works end‑to‑end. [DONE]
 
 ## Scope Boundaries (Out of Scope for MVP)
+
 - Multi‑tenant UI, user management UI, or admin console.
 - Non‑Keycloak identity providers and non‑Traefik ingress.
 - Traefik ForwardAuth or centralized auth proxy.
@@ -367,6 +402,7 @@ Accepted ADRs
 - Advanced monitoring stack (Prometheus/Grafana) beyond Traefik metrics.
 
 ## FR/NFR → Gates & Evidence Map
+
 - FR1/FR2 (PRM + 401 hint) → Gate A → sample_deep_research_mcp (RemoteAuthProvider) + docs/validation.md steps 1 & 3.
 - FR3 (JWT validation iss/aud/JWKS) → Gate B → JWTVerifier config via env; curl OIDC + signed token test.
 - FR4/FR8 (Streamable‑HTTP preferred + streaming acceptance) → Gate C → scripts/stream_smoke.py, validate_mvp.sh.
@@ -376,20 +412,24 @@ Accepted ADRs
 - NFRs (SLOs, security) → Gate D → SLOs section and security controls.
 
 ## Deployment & CI/CD (MVP)
+
 - Environments: local (venv), compose (staging/prod style). Single image artifact.
 - Release: update image and compose; rollback via previous image tag.
 - CI: Lint + minimal smoke (build image, run `python -m pyflakes` if configured). Full CI deferred.
 
 ## Status
+
 Ready for Implementation
 
 Sign‑Off
+
 - Deciders: Architect, PM (Security consulted for auth/networking)
 - Date: 2025-09-15
 
 ---
 
 ## Elicitation Plan (Pre‑Dev Questions)
+
 - Identity & OAuth:
   - KC realm URL and client config? Token TTL, clock skew, and refresh policy?
   - Required scopes (if any) for tools; are fine‑grained scopes needed?
@@ -411,6 +451,7 @@ Sign‑Off
   - Threats of concern (DoS, token replay, trace leakage) and acceptance posture?
 
 ## Architecture Decisions (ADR Summary)
+
 - ADR‑001: Prefer Streamable‑HTTP; keep SSE as fallback.
   - Rationale: Lower latency, fewer redirects; aligns with client expectations.
 - ADR‑002: In‑app JWT verification; Traefik handles TLS/routing only.
@@ -423,17 +464,19 @@ Sign‑Off
   - Rationale: Container networking; safety in local runs.
 
 ## Sequence Flows (Text)
+
 - Unauthenticated request → PRM hint:
-  1) Client → `GET /mcp` → Server returns `401` with `WWW-Authenticate: Bearer resource_metadata="<PRM>"`.
+  1. Client → `GET /mcp` → Server returns `401` with `WWW-Authenticate: Bearer resource_metadata="<PRM>"`.
 - OAuth login via PRM:
-  1) Client reads PRM; 2) Client discovers AS metadata; 3) Auth Code + PKCE; 4) Token; 5) Calls MCP with Bearer.
+  1. Client reads PRM; 2) Client discovers AS metadata; 3) Auth Code + PKCE; 4) Token; 5) Calls MCP with Bearer.
 - Authenticated Streamable‑HTTP tool call:
-  1) Client POSTs to `/mcp` with Bearer; 2) Server verifies JWT (iss/aud/exp/nbf);
-  3) Session established; 4) Tool executes; 5) Streamed chunks returned; 6) Audit log written.
+  1. Client POSTs to `/mcp` with Bearer; 2) Server verifies JWT (iss/aud/exp/nbf);
+  2. Session established; 4) Tool executes; 5) Streamed chunks returned; 6) Audit log written.
 - SSE fallback:
-  1) Client connects `/sse`; 2) Messages via `/messages/`; 3) Same auth checks enforced.
+  1. Client connects `/sse`; 2) Messages via `/messages/`; 3) Same auth checks enforced.
 
 ### ASCII Sequence Diagram (MVP)
+
 ```text
 Client (ChatGPT)          Traefik                   MCP Server                     Keycloak (Auth)
       |                     |                            |                                  |
@@ -457,23 +500,26 @@ Client (ChatGPT)          Traefik                   MCP Server                  
 ```
 
 ### Traefik Rate Limit Middleware (Example)
+
 Add this to compose labels to protect the MCP router:
+
 ```yaml
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.mcp.rule=Host(`mcp.localhost`)
-      - traefik.http.routers.mcp.entrypoints=websecure
-      - traefik.http.routers.mcp.tls=true
-      - traefik.http.routers.mcp.tls.certresolver=dev
-      - traefik.http.services.mcp.loadbalancer.server.port=8000
-      # Rate limit: average 50 rps with burst 25 over 1s per source IP
-      - traefik.http.middlewares.mcp-rl.ratelimit.average=50
-      - traefik.http.middlewares.mcp-rl.ratelimit.burst=25
-      - traefik.http.middlewares.mcp-rl.ratelimit.period=1s
-      - traefik.http.routers.mcp.middlewares=mcp-rl
+labels:
+  - traefik.enable=true
+  - traefik.http.routers.mcp.rule=Host(`mcp.localhost`)
+  - traefik.http.routers.mcp.entrypoints=websecure
+  - traefik.http.routers.mcp.tls=true
+  - traefik.http.routers.mcp.tls.certresolver=dev
+  - traefik.http.services.mcp.loadbalancer.server.port=8000
+  # Rate limit: average 50 rps with burst 25 over 1s per source IP
+  - traefik.http.middlewares.mcp-rl.ratelimit.average=50
+  - traefik.http.middlewares.mcp-rl.ratelimit.burst=25
+  - traefik.http.middlewares.mcp-rl.ratelimit.period=1s
+  - traefik.http.routers.mcp.middlewares=mcp-rl
 ```
 
 ## Threat Model (STRIDE) & Controls
+
 - Spoofing: JWT verification (JWKS, iss/aud), TLS, header‑only Bearer.
 - Tampering: TLS 1.2+; reject tokens with invalid signature or claims.
 - Repudiation: JSON audit logs (request_id, sub, client_id, outcome, reason).
@@ -482,6 +528,7 @@ Add this to compose labels to protect the MCP router:
 - Elevation of Privilege: Optional scopes; least‑privilege tool set; no token in URL.
 
 ## Performance & SLOs (MVP Targets)
+
 - Availability: 99.5% monthly.
 - TTFB (stream start): < 2s p95 via Traefik.
 - Stream cadence: ≥ 10 chunks for representative long tools; keep‑alive every ≤ 30s.
@@ -490,6 +537,7 @@ Add this to compose labels to protect the MCP router:
 - Timeouts: Client idle 90s; request timeout 120s; JWKS cache TTL 60m.
 
 ## Ops Runbook (MVP)
+
 - Health: `GET /healthz` (200 `{ok:true}`).
 - Logs: JSON lines with `request_id`, `transport`, `latency_ms`, `client_id?`.
 - JWKS: Cache and refresh on key rotation; restart not required.
@@ -498,6 +546,7 @@ Add this to compose labels to protect the MCP router:
 - Incident: Capture request_id and timeframe; verify JWKS and Traefik health; tail logs by service.
 
 ## Definition of Ready (for Dev)
+
 - Hostnames, TLS, and `.env` values confirmed and versioned.
 - KC realm and client exist; redirect URIs registered; token TTLs chosen.
 - Audience policy decided; fallback audience (if any) documented.
@@ -505,12 +554,14 @@ Add this to compose labels to protect the MCP router:
 - Logging fields agreed; retention and redaction requirements documented.
 
 ## Outstanding Risks & Open Questions
+
 - Streamable‑HTTP availability across client variants; fallback performance.
 - Audience mismatch in some clients; whether to keep fallback beyond MVP.
 - Rate limiting policy (Traefik vs app) and thresholds.
 - Long‑running tools and chunk sizing; backpressure behavior.
 
 ## Architecture Sign‑Off Checklist
+
 - Requirements mapped to gates (A–D) with evidence plan.
 - ADRs recorded and accepted by stakeholders.
 - Threat model reviewed; mitigations accepted.

--- a/docs/brownfield-architecture.md
+++ b/docs/brownfield-architecture.md
@@ -231,7 +231,7 @@ CMD ["python", "sample_mcp.py"]
 
 ```yaml
 # ./compose.yaml (reference)
-version: '3.9'
+version: "3.9"
 services:
   traefik:
     image: traefik:v3.1
@@ -242,7 +242,7 @@ services:
       - --certificatesresolvers.dev.acme.tlschallenge=true
       - --certificatesresolvers.dev.acme.email=you@example.com
       - --certificatesresolvers.dev.acme.storage=/letsencrypt/acme.json
-    ports: ['80:80', '443:443']
+    ports: ["80:80", "443:443"]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik_data:/letsencrypt
@@ -254,11 +254,11 @@ services:
       MCP_SERVER_URL: https://mcp.localhost
       KC_ISSUER: https://auth.localhost/realms/mcp
       MCP_AUDIENCE: https://mcp.localhost
-      MCP_ALT_AUDIENCE: '' # optional fallback; leave empty by default
+      MCP_ALT_AUDIENCE: "" # optional fallback; leave empty by default
       BIND_HOST: 0.0.0.0
       BIND_PORT: 8000
       LOG_LEVEL: info
-    expose: ['8000']
+    expose: ["8000"]
     labels:
       - traefik.enable=true
       - traefik.http.routers.mcp.rule=Host(`mcp.localhost`)
@@ -272,12 +272,12 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:25.0
-    command: ['start']
+    command: ["start"]
     environment:
       KC_PROXY: edge
       KC_HOSTNAME: auth.localhost
-      KC_HTTP_ENABLED: 'true'
-    expose: ['8080']
+      KC_HTTP_ENABLED: "true"
+    expose: ["8080"]
     labels:
       - traefik.enable=true
       - traefik.http.routers.kc.rule=Host(`auth.localhost`)
@@ -470,8 +470,12 @@ Sign‑Off
 - OAuth login via PRM:
   1. Client reads PRM; 2) Client discovers AS metadata; 3) Auth Code + PKCE; 4) Token; 5) Calls MCP with Bearer.
 - Authenticated Streamable‑HTTP tool call:
-  1. Client POSTs to `/mcp` with Bearer; 2) Server verifies JWT (iss/aud/exp/nbf);
-  2. Session established; 4) Tool executes; 5) Streamed chunks returned; 6) Audit log written.
+  1. Client POSTs to `/mcp` with Bearer.
+  2. Server verifies JWT (iss/aud/exp/nbf).
+  3. Session established.
+  4. Tool executes.
+  5. Streamed chunks returned.
+  6. Audit log written.
 - SSE fallback:
   1. Client connects `/sse`; 2) Messages via `/messages/`; 3) Same auth checks enforced.
 
@@ -501,21 +505,24 @@ Client (ChatGPT)          Traefik                   MCP Server                  
 
 ### Traefik Rate Limit Middleware (Example)
 
-Add this to compose labels to protect the MCP router:
+Add this to your service definition to protect the MCP router:
 
 ```yaml
-labels:
-  - traefik.enable=true
-  - traefik.http.routers.mcp.rule=Host(`mcp.localhost`)
-  - traefik.http.routers.mcp.entrypoints=websecure
-  - traefik.http.routers.mcp.tls=true
-  - traefik.http.routers.mcp.tls.certresolver=dev
-  - traefik.http.services.mcp.loadbalancer.server.port=8000
-  # Rate limit: average 50 rps with burst 25 over 1s per source IP
-  - traefik.http.middlewares.mcp-rl.ratelimit.average=50
-  - traefik.http.middlewares.mcp-rl.ratelimit.burst=25
-  - traefik.http.middlewares.mcp-rl.ratelimit.period=1s
-  - traefik.http.routers.mcp.middlewares=mcp-rl
+services:
+  mcp:
+    # ... other service config
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.mcp.rule=Host(`mcp.localhost`)
+      - traefik.http.routers.mcp.entrypoints=websecure
+      - traefik.http.routers.mcp.tls=true
+      - traefik.http.routers.mcp.tls.certresolver=dev
+      - traefik.http.services.mcp.loadbalancer.server.port=8000
+      # Rate limit: average 50 rps with burst 25 over 1s per source IP
+      - traefik.http.middlewares.mcp-rl.ratelimit.average=50
+      - traefik.http.middlewares.mcp-rl.ratelimit.burst=25
+      - traefik.http.middlewares.mcp-rl.ratelimit.period=1s
+      - traefik.http.routers.mcp.middlewares=mcp-rl
 ```
 
 ## Threat Model (STRIDE) & Controls

--- a/docs/onboarding-chatgpt.md
+++ b/docs/onboarding-chatgpt.md
@@ -5,17 +5,20 @@ This guide connects ChatGPT to the OAuth‑secured Sample MCP in this repo.
 Date: 2025-09-15
 
 ## Prerequisites
+
 - Stack running via `docker compose up -d` with valid `.env`.
 - Hostnames resolve: `mcp.localhost`, `auth.localhost` → 127.0.0.1.
 - PRM and OIDC discovery validated (see docs/validation.md).
 - You have a plan that supports custom MCP connectors in ChatGPT (see Help Center for availability and roles).
 
 References
+
 - Connectors in ChatGPT (custom MCP support, how to connect; notes on required tools). [OpenAI Help]  
-  Settings → Connectors → add app; custom connectors require tools `search` and `fetch`.  
-- MCP Authorization and PRM (spec).  
+  Settings → Connectors → add app; custom connectors require tools `search` and `fetch`.
+- MCP Authorization and PRM (spec).
 
 ## 1) Confirm server readiness
+
 ```bash
 curl -sS https://mcp.localhost/.well-known/oauth-protected-resource | jq
 curl -sS https://auth.localhost/realms/mcp/.well-known/openid-configuration | jq '.issuer,.jwks_uri'
@@ -23,6 +26,7 @@ curl -isk https://mcp.localhost/mcp | sed -n '1,15p'  # expect 401 + WWW-Authent
 ```
 
 ## 2) Add the connector in ChatGPT
+
 1. Open ChatGPT (web or desktop) and sign in.
 2. Go to Settings → Connectors.
 3. Choose “Custom Connectors (MCP)” and click Connect.
@@ -30,10 +34,12 @@ curl -isk https://mcp.localhost/mcp | sed -n '1,15p'  # expect 401 + WWW-Authent
 5. Complete the Keycloak login and consent. PKCE is handled by ChatGPT.
 
 Notes
+
 - In Business/Enterprise/Edu workspaces, only owners/admins (or users granted permission) can add custom connectors. After enabling, members still authenticate individually on first use.
 - If you see “This MCP server doesn’t implement our specification,” confirm the server exposes tools named `search` and `fetch` (this sample does).
 
 ## 3) Use the connector in chat
+
 1. Open a new chat.
 2. Click Tools → Use connectors → select your new connector (name may include host).
 3. Try:
@@ -41,16 +47,18 @@ Notes
    - Then call fetch by ID returned by search.
 
 Expected behavior
+
 - Chat shows connector enabled. Tool calls stream via Streamable‑HTTP (preferred). SSE is available as fallback.
 - Authorization: first call redirects you to login if the token isn’t present; subsequent calls send Bearer tokens header‑only.
 
 ## 4) Troubleshooting
+
 - 401 without OAuth prompt: confirm PRM endpoint and that `KC_ISSUER` matches your realm public URL.
 - Audience mismatch: set `MCP_AUDIENCE` = `MCP_SERVER_URL`, and optionally `MCP_ALT_AUDIENCE` if required by the client; restart container.
 - TLS/host mismatch: ensure Traefik certificate covers `mcp.localhost` and `.env` URLs match.
 - “Spec not implemented”: confirm tools `search` and `fetch` exist and are visible.
 
 ## 5) Capture evidence for Gate D
+
 - Screenshot the connector configuration and the first successful search + fetch in ChatGPT.
 - Save server logs that show a validated JWT (`iss`, `aud`) and Streamable‑HTTP request path `/mcp`.
-

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -5,11 +5,13 @@
 ## Goals and Background Context
 
 ### Goals
+
 - Establish a repeatable framework for creating MCP servers secured with Keycloak‑provided OAuth 2.1, compatible with ChatGPT’s MCP Developer Mode connectors.
 - Deliver a working OAuth-secured sample MCP server at `sample-deep-research-mcp` that remains fully functional when connected to ChatGPT.
 - Keep scope minimal: prioritize OAuth compatibility and stability over additional features.
 
 ### Status & KPIs (MVP)
+
 - Target readiness: Architecture “Ready for Implementation” by 2025-09-20.
 - Bootstrap time: ≤ 30 minutes to bring up a new OAuth‑enabled MCP from the sample.
 - Streaming TTFB: < 2s p95 through Traefik (see architecture SLOs).
@@ -22,20 +24,22 @@ Problem Statement: Create a repeatable OAuth 2.1 framework for MCP servers beh
 This project aims to standardize how multiple MCP servers authenticate via OAuth (Keycloak) while remaining fully compatible with ChatGPT’s MCP Developer Mode connectors, including deep-research style connectors that require no tool-type limits and write capabilities. The immediate objective is to secure the included sample server and establish a pattern that can be reused for additional MCP servers with minimal effort. Primary user is the project maintainer (single-user scenario) running on Linux and ultimately deploying via Docker.
 
 ### Change Log
-| Date       | Version | Description                     | Author |
-|------------|---------|---------------------------------|--------|
-| 2025-09-14 | 0.1     | Initial scaffold created        | PM     |
-| 2025-09-15 | 0.2     | Populated goals/background; added constraints and metrics | PM |
-| 2025-09-15 | 0.3     | Preferred Streamable‑HTTP; added Traefik ingress section; replaced FR/NFR; expanded risks | PM |
-| 2025-09-15 | 0.4     | Added Epic List, sequenced stories, and acceptance gates | PM |
-| 2025-09-15 | 0.5     | MVP clarifies in‑app JWT (no ForwardAuth); stronger Streamable‑HTTP acceptance; Traefik noted as router/TLS only | PM |
-| 2025-09-15 | 0.6     | Added Problem Statement, Out‑of‑Scope, and Performance & Reliability notes | PM |
-| 2025-09-15 | 0.7     | Noted local `fastmcp/` reference repo; clarified container bind (0.0.0.0) vs local (127.0.0.1) | PM |
-| 2025-09-15 | 0.8     | Added explicit Out‑of‑Scope, Status & KPIs, and references to architecture SLOs/evidence map | PM |
+
+| Date       | Version | Description                                                                                                      | Author |
+| ---------- | ------- | ---------------------------------------------------------------------------------------------------------------- | ------ |
+| 2025-09-14 | 0.1     | Initial scaffold created                                                                                         | PM     |
+| 2025-09-15 | 0.2     | Populated goals/background; added constraints and metrics                                                        | PM     |
+| 2025-09-15 | 0.3     | Preferred Streamable‑HTTP; added Traefik ingress section; replaced FR/NFR; expanded risks                        | PM     |
+| 2025-09-15 | 0.4     | Added Epic List, sequenced stories, and acceptance gates                                                         | PM     |
+| 2025-09-15 | 0.5     | MVP clarifies in‑app JWT (no ForwardAuth); stronger Streamable‑HTTP acceptance; Traefik noted as router/TLS only | PM     |
+| 2025-09-15 | 0.6     | Added Problem Statement, Out‑of‑Scope, and Performance & Reliability notes                                       | PM     |
+| 2025-09-15 | 0.7     | Noted local `fastmcp/` reference repo; clarified container bind (0.0.0.0) vs local (127.0.0.1)                   | PM     |
+| 2025-09-15 | 0.8     | Added explicit Out‑of‑Scope, Status & KPIs, and references to architecture SLOs/evidence map                     | PM     |
 
 ## Requirements
 
 ### Functional (FR)
+
 - FR1: Serve PRM at `/.well-known/oauth-protected-resource` advertising at least one Authorization Server (Keycloak) and the canonical MCP base URL. Include PRM per RFC 9728; `resource` equals `MCP_SERVER_URL`.
 - FR2: Return 401 with `WWW-Authenticate: Bearer resource_metadata="<PRM URL>"` for unauthenticated protected endpoints.
 - FR3: Validate bearer JWTs using Keycloak JWKS; enforce `iss` (realm public URL) and audience bound to the MCP base (accept configured fallback audience if needed for ChatGPT compatibility, with audit logging). Bearer tokens MUST be in the `Authorization` header only; never in query or path.
@@ -48,6 +52,7 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - FR9: Preserve all existing sample server tool functionality when authenticated via ChatGPT Developer‑mode.
 
 ### Non-Functional (NFR)
+
 - NFR1: Linux + Docker deployment; configuration is label/env‑driven only.
 - NFR2: OAuth 2.1 Authorization Code with PKCE (S256); Authorization Server exposes RFC 8414 metadata.
 - NFR3: No realm structural changes; updating client redirect URIs is permitted.
@@ -56,6 +61,7 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - NFR6: Bootstrap a new OAuth‑enabled MCP from the sample in ≤ 30 minutes.
 
 ## Out of Scope (MVP)
+
 - Multi‑tenant UI, user management UI, or admin console.
 - Non‑Keycloak identity providers or non‑Traefik ingress.
 - Traefik ForwardAuth/centralized auth proxy in MVP (in‑app JWT used).
@@ -63,9 +69,11 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - Advanced monitoring stack beyond Traefik metrics; app‑level metrics deferred.
 
 ## User Interface Design Goals
+
 - TBD — captured after requirements pass 1.
 
 ## Technical Assumptions
+
 - Tech stack: FastMCP framework.
 - AuthN/AuthZ: OAuth 2.1 Authorization Code with PKCE (S256) via Keycloak; Authorization Server exposes RFC 8414 metadata.
 - Host OS: Linux for development; containerized deployment via Docker.
@@ -73,16 +81,19 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - Transport: Streamable‑HTTP preferred; SSE supported as fallback for compatibility.
 - JWT validation occurs in‑app for MVP (no Traefik ForwardAuth); Traefik provides TLS termination and routing only.
 - Scope restraint: No additional feature work beyond securing and validating the sample server.
- - Local reference: `fastmcp/` repository is included for implementation details (transports, examples) to inform Epic 1.
+- Local reference: `fastmcp/` repository is included for implementation details (transports, examples) to inform Epic 1.
 
 ## Data Model Overview
+
 - TBD.
 
 ## Integrations
+
 - Keycloak (OAuth 2.1 provider).
 - ChatGPT MCP Developer Mode (client/connectors).
 
 ## Ingress & Routing (Traefik)
+
 - TLS via Traefik with valid certificates matching public hostnames.
 - Route MCP host to container service/port using labels; no static Traefik files.
 - Provide optional RFC 8414 path‑insert shims via `replacePathRegex` to map to Keycloak realm‑first endpoints.
@@ -90,6 +101,7 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - MVP: do not enable ForwardAuth; consider edge auth post‑MVP if multiple services need centralized policy. Ensure unauthenticated 401 originates from the MCP app with proper PRM hint.
 
 ## Performance & Reliability Notes (MVP)
+
 - Streaming: Streamable‑HTTP initial headers within ~2s; support long‑lived sessions (≥10 minutes) via Traefik timeouts/keep‑alive.
 - SSE Fallback: If used, send keep‑alive events (e.g., every 15s) to prevent idle closure.
 - Healthcheck: Expose `GET /healthz` (200) and container `HEALTHCHECK` probing that endpoint.
@@ -97,10 +109,12 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - Observability: Include request ID correlation in logs; redact Authorization headers.
 
 ## Release Strategy
+
 - MVP: Secure `sample-deep-research-mcp` with OAuth and validate end‑to‑end functionality in ChatGPT.
 - Post‑MVP: Template/boilerplate for rapidly adding new OAuth‑enabled MCP servers.
 
 ## Out of Scope (MVP)
+
 - End‑user UI/portal and multi‑tenant user management.
 - Non‑Keycloak identity providers or SAML/OAuth hybrids.
 - Non‑Traefik ingress controllers or Kubernetes manifests.
@@ -109,6 +123,7 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - Advanced rate limiting, billing, or audit/compliance reporting beyond basic logs.
 
 ## Risks & Mitigations
+
 - TLS/Certificates: Invalid SANs or mismatched hosts → Use Traefik TLS with correct hosts; ensure `MCP_SERVER_URL` matches.
 - RFC 8414 Discovery Shape: Path‑insert vs realm‑first → Add Traefik replace‑path shims; confirm both discovery URLs resolve.
 - Redirect URIs: Missing/incorrect in existing Keycloak client → Register exact HTTPS callbacks (may be the only Keycloak change).
@@ -121,10 +136,12 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
 - Env Drift: `MCP_SERVER_URL` / `KC_ISSUER` / `MCP_AUDIENCE` inconsistencies → Single `.env.example`; reference consistently.
 
 ## Success Metrics
+
 - “Done” for MVP: Included sample MCP server works properly with OAuth in ChatGPT, preserving all existing functionality.
 - Repeatability: New OAuth‑enabled MCP server can be bootstrapped in ≤30 minutes following the template.
 
 ## Epic List
+
 - Epic 1: OAuth‑Secured Sample MCP
   - Deliver Streamable‑HTTP MCP behind Traefik with TLS.
   - Publish PRM and 401 `WWW-Authenticate` hint per RFC 9728.
@@ -139,6 +156,7 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
   - “New server in ≤30 minutes” walkthrough + smoke test.
 
 ### Epic 1 Stories (Sequential)
+
 - S1: Bootstrap env and healthcheck
   - Output: `.env.example`; health endpoint routed via Traefik HTTPS.
 - S2: Traefik routing + TLS labels
@@ -155,15 +173,18 @@ This project aims to standardize how multiple MCP servers authenticate via OAuth
   - Output: Connector added; end‑to‑end tool calls succeed; scripts confirm PRM/AS/401/stream.
 
 ### Acceptance Gates (Map to FR/NFR)
+
 - Gate A (after S3): FR1–FR2 satisfied.
 - Gate B (after S4): FR3, NFR2 satisfied.
 - Gate C (after S5): FR4, FR8 satisfied.
 - Gate D (after S7): FR9 + Success Metrics “Done for MVP”.
 
 References
+
 - See docs/brownfield-architecture.md sections “FR/NFR → Gates & Evidence Map” and “Performance & SLOs (MVP Targets)” for detailed evidence and targets.
 
 ## Deployment Parameters (To Be Confirmed)
+
 - MCP Hostname (prod): <mcp.example.com>
 - Auth Hostname (prod): <auth.example.com>
 - ACME Contact Email: <ops@example.com>
@@ -171,25 +192,29 @@ References
 - DNS: A/AAAA records to Traefik ingress; internal networking unchanged
 
 ## Responsibility Matrix (MVP)
-| Task | Owner | When |
-|------|-------|------|
-| Register/confirm DNS for MCP/Auth | Human (Ops) | Before S2 |
-| Configure ACME email/cert resolver | Human (Ops) | Before S2 |
+
+| Task                                                   | Owner           | When         |
+| ------------------------------------------------------ | --------------- | ------------ |
+| Register/confirm DNS for MCP/Auth                      | Human (Ops)     | Before S2    |
+| Configure ACME email/cert resolver                     | Human (Ops)     | Before S2    |
 | Create Keycloak realm + client; register redirect URIs | Human (Ops/Sec) | Before S3–S4 |
-| Implement PRM/401/JWT/transport per FRs | Dev Agent | S3–S5 |
-| Configure Traefik labels, TLS, and discovery shim | Dev Agent | S2, S6 |
-| Run validation scripts and capture evidence | Dev Agent | Gates A–C |
-| Add ChatGPT connector and authenticate | Human (User) | S7 |
+| Implement PRM/401/JWT/transport per FRs                | Dev Agent       | S3–S5        |
+| Configure Traefik labels, TLS, and discovery shim      | Dev Agent       | S2, S6       |
+| Run validation scripts and capture evidence            | Dev Agent       | Gates A–C    |
+| Add ChatGPT connector and authenticate                 | Human (User)    | S7           |
 
 ## CI/CD Note (MVP)
+
 - CI: Lint + build image + minimal smoke (health endpoint curl via ephemeral container).
 - Artifacts: Docker image tagged per commit; compose-driven release.
 - Rollback: Re-deploy previous image tag; revert compose labels if needed.
 
 ## Checklist Results Report
- - PM Checklist: Comprehensive mode run on 2025-09-15
+
+- PM Checklist: Comprehensive mode run on 2025-09-15
 
 Summary
+
 - Problem Definition & Context: PASS (minor clarifications suggested)
 - MVP Scope Definition: PASS (explicit out-of-scope recommended)
 - UX Requirements: WAIVED (backend service; no end-user UI)
@@ -197,6 +222,7 @@ Summary
 - Non-Functional Requirements: PASS with notes (security solid; perf/reliability minimal for MVP)
 
 Details
+
 - 1.1 Problem Statement: PASS — Goal and audience (single maintainer) clear; add a one-line explicit problem statement for clarity.
 - 1.2 Goals & Success Metrics: PASS — “MVP done in ChatGPT” and “≤30 min bootstrap” measurable; consider adding a target date/baseline.
 - 1.3 Research & Insights: WAIVED — internal tool for solo maintainer; no market research required.
@@ -211,9 +237,11 @@ Details
 - 5.4 Technical Constraints: PASS — FastMCP, Keycloak, Traefik, Docker captured.
 
 Action Items
+
 - A1: Add Out-of-Scope list under Release Strategy or a new section. [Owner: PM]
 - A2: Add one‑line explicit problem statement at top of Background. [Owner: PM]
 - A3: Record minimal perf/reliability notes (timeouts, healthcheck, restart). [Owner: PM]
 
 ## Next Steps
+
 - Draft UX Expert prompt after PRD first pass.

--- a/docs/qa/assessments/2.1-po-validation-20250916.md
+++ b/docs/qa/assessments/2.1-po-validation-20250916.md
@@ -1,0 +1,28 @@
+# PO Validation: Story 2.1 — Repo-Level Ruff & Prettier Baseline
+
+Date: 2025-09-16
+Story: docs/stories/2.1.repo-level-ruff-prettier-baseline.md
+
+## Checklist Summary
+- Clarity: Story articulates the need for repo-wide lint/format baseline tied to Issue #5. PASS.
+- Acceptance Criteria: Objective, measurable commands (Ruff, Prettier, documentation) map to success metrics. PASS.
+- Tasks: Subtasks cover configuration, automation, command validation, and documentation updates with clear owners. PASS.
+- Dependencies: References seed epic and issue; no hidden blockers beyond existing GitHub access. PASS.
+- References: Links to Ruff docs, Prettier release, and issue are present. PASS.
+- Sequencing: Appropriately positioned as S1 for Epic 2 before CI/coverage stories. PASS.
+
+## Decision
+Validation Result: PASS (Story Draft)
+
+Notes:
+- Ensure README update explicitly points to `uvx pre-commit install` instructions to address OPS-205 risk.
+- Add pointer in acceptance evidence to CI lint job once story is implemented to aid SM/QA traceability.
+
+---
+
+## Implementation Review (2025-09-16)
+- Documentation update delivered via `docs/testing.md` with explicit `uvx pre-commit install` note. PASS.
+- Issue #5 comment confirms lint/format commands executed with clean results. PASS.
+- Ruff config and pre-commit hooks verified by QA gate file (docs/qa/gates/2.1-repo-level-ruff-prettier-baseline.yml). PASS.
+
+Final Decision: **READY FOR MERGE** — Story 2.1 meets acceptance criteria and supporting evidence is recorded.

--- a/docs/qa/assessments/2.1-review-20250916.md
+++ b/docs/qa/assessments/2.1-review-20250916.md
@@ -1,0 +1,20 @@
+# QA Review: Story 2.1 — Repo-Level Ruff & Prettier Baseline
+
+Date: 2025-09-16
+Reviewer: Quinn (Test Architect)
+
+## Summary
+- Scope aligns with Epic 2 Seed S1. Implementation introduces shared Ruff config, repo-level pre-commit hooks, and contributor documentation.
+- Validation commands executed on feature branch: `uvx ruff check .`, `uvx ruff format --check .`, `npx prettier --check '**/*.{md,mdx,json,yaml,yml}'`.
+- Issue #5 comment (2025-09-16) logs successful runs and new file locations.
+
+## Findings
+- ✅ Root `pyproject.toml` enumerates intended directories and sets `target-version = "py311"` (matches project baseline).
+- ✅ `.pre-commit-config.yaml` pins Ruff v0.5.7 and Prettier v3.3.2 with explicit `types_or` coverage.
+- ✅ `.prettierignore` excludes large template directories, keeping hook focused on repo-owned docs.
+- ✅ Docs/testing quickstart provides step-by-step commands and troubleshooting hints.
+- ⚠️ Follow-up: consolidate `tool.ruff` settings under `fastmcp/pyproject.toml` (Story 2.2) to avoid divergence — tracked separately.
+
+## Decision
+- QA Review Result: PASS — ready to advance to QA Gate once trace/NFR recorded.
+- Evidence archived under docs/qa/assessments and Issue #5 comment.

--- a/docs/qa/assessments/2.1-risk-20250916.md
+++ b/docs/qa/assessments/2.1-risk-20250916.md
@@ -1,0 +1,93 @@
+# Risk Profile: Story 2.1 — Repo-Level Ruff & Prettier Baseline
+
+Date: 2025-09-16
+Reviewer: Quinn (Test Architect)
+
+## Executive Summary
+- Total Risks Identified: 7
+- Critical Risks: 0
+- High Risks: 2
+- Risk Score: 82/100 (calculated)
+
+Primary exposure is automation drift: without a unified configuration, linting and formatting regressions cascade into downstream stories and CI work. Operational risk also exists if pre-commit hooks block contributors or slow CI due to misconfiguration. Security and performance impacts are low, but developer productivity and tooling alignment are central.
+
+## Risk Distribution
+- Security: 0
+- Performance: 1 (0 critical)
+- Data: 0
+- Business: 1 (0 critical)
+- Operational: 5 (2 high)
+
+## Detailed Risk Register
+
+### OPS-201: Ruff configuration misses directories
+- Probability: High (3)
+- Impact: High (3)
+- Score: 9 (High)
+- Description: Root config neglects `sample-deep-research-mcp/` or `scripts/`, leaving unformatted code.
+- Mitigation: Explicit `src`/`extend` list; add regression tests that run Ruff over entire repo; document include paths.
+- Testing Focus: Execute Ruff commands in CI covering repo root; add unit tests for config inference if feasible.
+
+### OPS-202: Prettier hook under-scopes docs
+- Probability: Medium (2)
+- Impact: High (3)
+- Score: 6 (High)
+- Description: Hook globs exclude `.mdx` or nested docs, causing inconsistent doc diffs.
+- Mitigation: Use Prettier `types_or` or explicit glob; run `prettier --list-different"**/*.{md,mdx,json,yaml,yml}"` in CI.
+- Testing Focus: Command validation scenario ensures no pending changes after running Prettier.
+
+### OPS-203: Contributors blocked by aggressive autofix
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: `--fix` hooks rewrite imports unexpectedly or conflict with local editors.
+- Mitigation: Document workflow; provide `ruff check --exit-non-zero-on-fix` in CI but allow local opt-out via documentation.
+- Testing Focus: Smoke test pre-commit run on clean repo to ensure no infinite loops.
+
+### OPS-204: Duplicate Ruff configs drift
+- Probability: High (3)
+- Impact: Medium (2)
+- Score: 6 (Medium)
+- Description: fastmcp package retains separate settings causing conflicting ignores.
+- Mitigation: Consolidate configuration; add unit tests that parse config to ensure single source of truth.
+- Testing Focus: Validate `ruff settings` output once to confirm only root config is active.
+
+### PERF-201: CI duration spike from full-repo lint
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: Lint/format on large tree may exceed CI budget.
+- Mitigation: Use caching (`uv` cache, Prettier `cache: true`), parallelize where possible.
+- Testing Focus: Track CI runtime; set alert if lint stage >3 minutes.
+
+### BUS-201: Documentation not updated, onboarding confusion
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: Without docs, developers miss commands and skip hooks.
+- Mitigation: Update README/docs/testing; include commands in story acceptance criteria.
+- Testing Focus: Documentation review gate ensures updates exist.
+
+### OPS-205: Pre-commit environment mismatch
+- Probability: Low (1)
+- Impact: Medium (2)
+- Score: 2 (Low)
+- Description: `pre-commit` executes with system Python lacking `uvx`, causing hook failure.
+- Mitigation: Provide instructions using `repo: local` wrappers or `additional_dependencies`; test on clean machine.
+- Testing Focus: Run `pre-commit run --all-files` in CI container to detect mismatches.
+
+## Risk-Based Testing Strategy
+- Priority 1: Validate Ruff and Prettier commands across entire repo (CI + local) to ensure coverage (mitigates OPS-201/OPS-202).
+- Priority 2: Confirm configuration consolidation by auditing for duplicate `tool.ruff` sections (OPS-204).
+- Priority 3: Document workflow and collect feedback from developer dry-run (BUS-201/OPS-203).
+
+## Risk Acceptance Criteria
+- Must Fix Before Merge: OPS-201, OPS-202.
+- Can Defer with ticket: OPS-205 (documented fallback acceptable).
+
+## Monitoring Requirements (post-merge optional)
+- Add CI telemetry for lint stage runtime.
+- Track `pre-commit` failure rates in developer retro for two sprints post adoption.
+
+## Story Hook
+Risk profile: docs/qa/assessments/2.1-risk-20250916.md

--- a/docs/qa/assessments/2.1-test-design-20250916.md
+++ b/docs/qa/assessments/2.1-test-design-20250916.md
@@ -1,0 +1,85 @@
+# Test Design: Story 2.1 — Repo-Level Ruff & Prettier Baseline
+
+Date: 2025-09-16
+Designer: Quinn (Test Architect)
+
+## Test Strategy Overview
+- Total test scenarios: 8
+- Unit tests: 1 (12%)
+- Integration tests: 6 (75%)
+- E2E tests: 1 (13%)
+- Priority distribution: P0: 4, P1: 3, P2: 1
+
+Rationale: This story is tooling-heavy. Tests focus on command execution, configuration integrity, and documentation updates. Integration-level validation (running lint/format commands) provides highest assurance.
+
+## Test Scenarios by Acceptance Criteria
+
+### AC1: Root Ruff configuration scopes directories
+
+| ID           | Level       | Priority | Test                                                                 | Justification |
+| ------------ | ----------- | -------- | -------------------------------------------------------------------- | ------------- |
+| 2.1-UNIT-001 | Unit        | P0       | Parse root Ruff config and assert `src`/`extend` includes required dirs | Prevent missing coverage |
+| 2.1-INT-001  | Integration | P0       | `uvx ruff check --select I --force-exclude` against repo root exits 0 | Ensures config applied |
+
+### AC2: Repo-level pre-commit runs Ruff lint/format and Prettier
+
+| ID           | Level       | Priority | Test                                                                 | Justification |
+| ------------ | ----------- | -------- | -------------------------------------------------------------------- | ------------- |
+| 2.1-INT-002  | Integration | P0       | `pre-commit run --all-files ruff-check` exits 0 and makes no changes | Validates lint hook |
+| 2.1-INT-003  | Integration | P0       | `pre-commit run --all-files ruff-format` exits 0 (no pending fixes)   | Validates format hook |
+| 2.1-INT-004  | Integration | P1       | `pre-commit run --all-files prettier` exits 0 and touches expected file types | Covers Prettier scope |
+
+### AC3: Ruff commands pass cleanly
+
+| ID           | Level       | Priority | Test                                                                 | Justification |
+| ------------ | ----------- | -------- | -------------------------------------------------------------------- | ------------- |
+| 2.1-INT-005  | Integration | P0       | `uvx ruff check .` on clean tree returns 0                          | Confirms lint clean |
+| 2.1-INT-006  | Integration | P1       | `uvx ruff format --check .` returns 0                               | Confirms format clean |
+
+### AC4: Prettier check passes
+
+| ID           | Level       | Priority | Test                                                                 | Justification |
+| ------------ | ----------- | -------- | -------------------------------------------------------------------- | ------------- |
+| 2.1-INT-007  | Integration | P0       | `npx prettier --check '**/*.{md,mdx,json,yaml,yml}'` exits 0         | Validates doc formatting |
+
+### AC5: Documentation updated
+
+| ID           | Level       | Priority | Test                                                                 | Justification |
+| ------------ | ----------- | -------- | -------------------------------------------------------------------- | ------------- |
+| 2.1-E2E-001  | E2E         | P2       | Reviewer confirms README/docs/testing includes Ruff/Prettier commands | Human verification |
+
+## Risk Coverage
+- Mitigates OPS-201, OPS-202 via P0 command runs.
+- Addresses OPS-204 through unit parse test.
+- BUS-201 satisfied by documentation validation scenario.
+
+## Recommended Execution Order
+1. P0 unit config audit (2.1-UNIT-001).
+2. P0 integration commands (2.1-INT-001, 2.1-INT-002, 2.1-INT-003, 2.1-INT-005, 2.1-INT-007).
+3. P1 integration (2.1-INT-004, 2.1-INT-006).
+4. P2 documentation review (2.1-E2E-001).
+
+## Notes for Implementers
+- Unit config test can load TOML using Python `tomllib` and assert presence of directories in `tool.ruff.lint.extend` or `tool.ruff` field.
+- Consider adding `uvx ruff settings` command in CI to print effective config; compare expected directories.
+- Prettier commands should leverage the repo `.prettierrc` if introduced; ensure Node version compatibility (>=18).
+- Document fallback instructions for developers without global `npx` by pointing to `corepack enable` or `pnpm` alternative.
+
+## Gate Block (for future gate file)
+```yaml
+test_design:
+  scenarios_total: 8
+  by_level:
+    unit: 1
+    integration: 6
+    e2e: 1
+  by_priority:
+    p0: 4
+    p1: 3
+    p2: 1
+  coverage_gaps:
+    - Need follow-up ticket for performance benchmarking of lint stage if repo grows >5k files.
+```
+
+## Story Hook
+Test design matrix: docs/qa/assessments/2.1-test-design-20250916.md

--- a/docs/qa/assessments/2.1-trace-20250916.md
+++ b/docs/qa/assessments/2.1-trace-20250916.md
@@ -1,0 +1,14 @@
+# Requirements Trace: Story 2.1 — Repo-Level Ruff & Prettier Baseline
+
+Date: 2025-09-16
+Analyst: Quinn (Test Architect)
+
+| Acceptance Criterion | Implementation Artifact(s) | Validation Evidence |
+|----------------------|-----------------------------|--------------------|
+| AC1: Root Ruff config scopes `fastmcp/`, `tests/`, `sample-deep-research-mcp/`, `scripts/` with target version | `pyproject.toml` (`tool.ruff` src list + `target-version = "py311"`) | `uvx ruff settings --config pyproject.toml` (see developer log) |
+| AC2: Repo `.pre-commit-config.yaml` runs Ruff lint/format and Prettier ≥3.3 | `.pre-commit-config.yaml` referencing `astral-sh/ruff-pre-commit@v0.5.7`, `prettier@3.3.2` | QA review of config; `npx prettier --check` clean run |
+| AC3: `uvx ruff check` and `uvx ruff format --check` succeed | Dev log + command outputs (issue #5 comment) | Re-run log (2025-09-16) shows “All checks passed!” |
+| AC4: `npx prettier --check` reports zero changes | Prettier run after formatting updates | `npx prettier --check '**/*.{md,mdx,json,yaml,yml}'` → “All matched files use Prettier code style!” |
+| AC5: Documentation references commands | `docs/testing.md` quickstart (sections 1–5) | Manual review + link added in Issue #5 comment |
+
+Trace Outcome: All acceptance criteria satisfied with evidence captured in repo and Issue #5.

--- a/docs/qa/assessments/2.2-risk-20250916.md
+++ b/docs/qa/assessments/2.2-risk-20250916.md
@@ -1,0 +1,85 @@
+# Risk Profile: Story 2.2 — Harmonize Package Configs & Type Checks
+
+Date: 2025-09-16
+Reviewer: Quinn (Test Architect)
+
+## Executive Summary
+- Total Risks Identified: 6
+- Critical Risks: 0
+- High Risks: 2
+- Risk Score: 80/100 (calculated)
+
+Main exposure stems from configuration drift between the root and package scopes. A secondary risk is incomplete type-check coverage leading to false sense of safety. Operational disruption is moderate because configuration mistakes immediately cascade into tooling failures.
+
+## Risk Distribution
+- Security: 0
+- Performance: 1 (0 critical)
+- Data: 0
+- Business: 0
+- Operational: 5 (2 high)
+
+## Detailed Risk Register
+
+### OPS-221: Root and package Ruff configs diverge again
+- Probability: High (3)
+- Impact: High (3)
+- Score: 9 (High)
+- Description: Developers may reintroduce per-package ignores that override root baseline.
+- Mitigation: Automated check comparing `ruff settings` outputs; guidance in README.
+- Testing Focus: Integration command verifying same paths from repo root and package directory.
+
+### OPS-222: Type checker misses sample MCP directory
+- Probability: Medium (2)
+- Impact: High (3)
+- Score: 6 (High)
+- Description: `tool.ty.src.include` fails to include non-package code, leaving gaps.
+- Mitigation: Unit-ish audit of include list; regression test invoking ty on sample path.
+- Testing Focus: Ty command run; optional script verifying config contains expected paths.
+
+### OPS-223: Excess ignore codes hide real type errors
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: Blanket ignores remain without follow-up plan.
+- Mitigation: Document ignore rationale in Issue #5; create tickets for reduction.
+- Testing Focus: Manual review plus automation to detect high-count suppressions.
+
+### PERF-221: Ty execution time increases dramatically
+- Probability: Low (1)
+- Impact: Medium (2)
+- Score: 2 (Low)
+- Description: Additional directories slow type checker to unusable speeds.
+- Mitigation: Cache `.venv`/`__pycache__` excludes; monitor run time in CI.
+- Testing Focus: Record baseline runtime; raise alert if >5 minutes.
+
+### OPS-224: `uv run ty check` fails in CI environment
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: Ty may require environment variables or optional dependencies.
+- Mitigation: Document prerequisites; add dry-run in local validation script.
+- Testing Focus: Run command in workflow container (Story 2.4) once available.
+
+### OPS-225: Issue #5 comment omitted, stakeholders unaware of residual debt
+- Probability: Medium (2)
+- Impact: Low (1)
+- Score: 2 (Low)
+- Description: Without comment, risk tracking falls through.
+- Mitigation: Add acceptance criterion; SM/PO verify before closure.
+- Testing Focus: Manual review of GitHub issue comment thread.
+
+## Risk-Based Testing Strategy
+- Priority 1: Integration commands verifying `ruff settings` parity and `uv run ty check` success.
+- Priority 2: Audit of `tool.ty.rules` for high-count suppressions; ensure documentation captured in Issue #5.
+- Priority 3: Monitor ty runtime once CI story lands; create follow-up if >5 minutes.
+
+## Risk Acceptance Criteria
+- Must Fix Before Merge: OPS-221, OPS-222.
+- Can Defer With Ticket: OPS-223, OPS-224, OPS-225.
+
+## Monitoring Requirements (post-merge optional)
+- Add CI metric for ty check duration and failures.
+- Revisit ignore list after two sprints to assess reduction opportunities.
+
+## Story Hook
+Risk profile: docs/qa/assessments/2.2-risk-20250916.md

--- a/docs/qa/assessments/2.2-test-design-20250916.md
+++ b/docs/qa/assessments/2.2-test-design-20250916.md
@@ -1,0 +1,80 @@
+# Test Design: Story 2.2 — Harmonize Package Configs & Type Checks
+
+Date: 2025-09-16
+Designer: Quinn (Test Architect)
+
+## Test Strategy Overview
+- Total test scenarios: 7
+- Unit tests: 2 (29%)
+- Integration tests: 5 (71%)
+- E2E tests: 0
+- Priority distribution: P0: 4, P1: 2, P2: 1
+
+Focus areas: configuration integrity and type-check execution. Lightweight unit tests validate configuration parsing; integration tests ensure commands succeed across directories.
+
+## Test Scenarios by Acceptance Criteria
+
+### AC1: Package inherits root Ruff config
+
+| ID           | Level | Priority | Test                                                                     | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------------|---------------|
+| 2.2-UNIT-001 | Unit  | P0       | Load `pyproject.toml` and assert `tool.ruff` keys absent or delegated     | Prevent duplicate config |
+| 2.2-INT-001  | Int   | P0       | `uvx ruff settings --config pyproject.toml` from repo root equals output from `fastmcp/` | Validates inheritance |
+
+### AC2: Type checker includes shared modules/tests
+
+| ID           | Level | Priority | Test                                                                     | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------------|---------------|
+| 2.2-UNIT-002 | Unit  | P0       | Parse `tool.ty.src.include` list ensuring required paths present          | Guard against omissions |
+| 2.2-INT-002  | Int   | P0       | `uv run ty check` at repo root returns exit code 0                        | Core functionality |
+
+### AC3: Document ignores in Issue #5
+
+| ID           | Level | Priority | Test                                                                     | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------------|---------------|
+| 2.2-INT-003  | Int   | P1       | script or manual check confirming Issue #5 comment includes ignore summary | Traceability |
+
+### AC4: Consistent Ruff scopes
+
+| ID           | Level | Priority | Test                                                                     | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------------|---------------|
+| 2.2-INT-004  | Int   | P1       | `uvx ruff check sample-deep-research-mcp` executes without errors         | Smoke per-directory |
+
+### Additional Safeguards
+
+| ID           | Level | Priority | Test                                                                     | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------------|---------------|
+| 2.2-INT-005  | Int   | P2       | Measure `uv run ty check` runtime and record (<5 min)                     | Monitor perf risk |
+
+## Risk Coverage
+- OPS-221/OPS-222 mitigated via P0 tests.
+- OPS-223/OPS-225 addressed via documentation and Issue #5 check.
+
+## Recommended Execution Order
+1. Run unit config audits (2.2-UNIT-001, 2.2-UNIT-002).
+2. Execute P0 integration commands (2.2-INT-001, 2.2-INT-002).
+3. Perform Issue #5 confirmation (2.2-INT-003) and per-directory smoke (2.2-INT-004).
+4. Capture runtime metric (2.2-INT-005) for trend analysis.
+
+## Notes for Implementers
+- Unit tests can leverage Python `tomllib` to parse config into dicts.
+- Consider adding automation script to compare `ruff settings` outputs as part of CI.
+- Issue comment template should list ignore codes and counts for transparency.
+
+## Gate Block (for future gate file)
+```yaml
+test_design:
+  scenarios_total: 7
+  by_level:
+    unit: 2
+    integration: 5
+    e2e: 0
+  by_priority:
+    p0: 4
+    p1: 2
+    p2: 1
+  coverage_gaps: []
+```
+
+## Story Hook
+Test design matrix: docs/qa/assessments/2.2-test-design-20250916.md

--- a/docs/qa/assessments/2.3-risk-20250916.md
+++ b/docs/qa/assessments/2.3-risk-20250916.md
@@ -1,0 +1,93 @@
+# Risk Profile: Story 2.3 — Expand Unit & Integration Coverage
+
+Date: 2025-09-16
+Reviewer: Quinn (Test Architect)
+
+## Executive Summary
+- Total Risks Identified: 8
+- Critical Risks: 1
+- High Risks: 3
+- Risk Score: 90/100 (calculated)
+
+Coverage expansion touches live auth logic and streaming flows. The biggest risk is flaky or slow integration tests that block CI, followed closely by insufficient coverage enforcement failing to catch regressions.
+
+## Risk Distribution
+- Security: 2 (0 critical)
+- Performance: 2 (1 critical)
+- Data: 0
+- Business: 1 (0 critical)
+- Operational: 3 (2 high)
+
+## Detailed Risk Register
+
+### PERF-301: Streaming smoke test flakes or hangs (Critical)
+- Probability: Medium (2)
+- Impact: Critical (4)
+- Score: 8 (Critical)
+- Description: Long-running or hanging streaming tests can stall CI for minutes and erode trust.
+- Mitigation: Implement timeouts, use mocked auth tokens, run under integration marker.
+- Testing Focus: Ensure test completes <30s and includes timeout guard.
+
+### OPS-301: Coverage threshold misconfigured or bypassed
+- Probability: Medium (2)
+- Impact: High (3)
+- Score: 6 (High)
+- Description: `--cov-fail-under` not set or reports not generated.
+- Mitigation: Add explicit option in `pytest.ini`; confirm coverage artifacts exist.
+- Testing Focus: Validate coverage enforcement and artifact paths.
+
+### SEC-301: Auth edge-case tests use real credentials improperly
+- Probability: Low (1)
+- Impact: High (3)
+- Score: 3 (Medium)
+- Description: Tests might hard-code secrets or use production endpoints.
+- Mitigation: Use fixtures and environment variables; sanitize logs.
+- Testing Focus: Code review for secret usage.
+
+### OPS-302: Tests rely on network outside repo
+- Probability: Low (1)
+- Impact: Medium (2)
+- Score: 2 (Low)
+- Description: Streaming smoke might call internet resources.
+- Mitigation: Keep all traffic local; use in-memory server.
+
+### OPS-303: Coverage reports not reproducible locally
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: Paths differ between dev and CI causing inconsistent coverage.
+- Mitigation: Standardize output directory; update docs.
+
+### PERF-302: Coverage run time regresses significantly
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Mitigation: Use `--maxfail` for integration tests; parallelize with `pytest -n auto` later if needed.
+
+### BUS-301: Evidence missing (coverage summary not stored)
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Mitigation: Add acceptance criterion to upload or link coverage summary.
+
+### SEC-302: Error handling path untested leading to false confidence
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Mitigation: Add negative tests for `fetch` invalid ID and auth disabled flows.
+
+## Risk-Based Testing Strategy
+- Priority 1: Streaming integration test must include deterministic timeout and run under integration marker.
+- Priority 2: Enforce coverage threshold and confirm artifact creation.
+- Priority 3: Ensure negative-path tests exist for tool functions and auth toggles.
+
+## Risk Acceptance Criteria
+- Must Fix Before Merge: PERF-301, OPS-301.
+- Can Defer With Ticket: OPS-303, PERF-302.
+
+## Monitoring Requirements (post-merge optional)
+- Track historical coverage percentage trend.
+- Monitor average runtime of `uv run pytest --cov` in CI.
+
+## Story Hook
+Risk profile: docs/qa/assessments/2.3-risk-20250916.md

--- a/docs/qa/assessments/2.3-test-design-20250916.md
+++ b/docs/qa/assessments/2.3-test-design-20250916.md
@@ -1,0 +1,92 @@
+# Test Design: Story 2.3 — Expand Unit & Integration Coverage
+
+Date: 2025-09-16
+Designer: Quinn (Test Architect)
+
+## Test Strategy Overview
+- Total test scenarios: 10
+- Unit tests: 4 (40%)
+- Integration tests: 6 (60%)
+- E2E tests: 0 (integration covers streaming)
+- Priority distribution: P0: 6, P1: 3, P2: 1
+
+Goal is to raise confidence around sample MCP functionality and streaming. Unit coverage ensures deterministic behavior; integration tests validate runtime wiring.
+
+## Test Scenarios by Acceptance Criteria
+
+### AC1: Unit coverage for `search`
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.3-UNIT-001 | Unit  | P0       | `search` returns expected results for keyword hit                   | Guard core behavior |
+| 2.3-UNIT-002 | Unit  | P0       | `search` returns empty list when no matches                         | Negative path |
+
+### AC1/AC2: Unit coverage for `fetch`
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.3-UNIT-003 | Unit  | P0       | `fetch` returns structured result for known ID                      | Contract |
+| 2.3-UNIT-004 | Unit  | P0       | `fetch` raises ValueError for unknown ID                            | Error handling |
+
+### AC2: Auth edge cases
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.3-INT-001  | Int   | P0       | Auth-enabled server: JWT fallback path exercised (primary + alt audience) | Validate env logic |
+| 2.3-INT-002  | Int   | P1       | Auth-disabled server: ensure no auth provider configured            | Prevent regressions |
+
+### AC3: Streaming smoke via pytest
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.3-INT-003  | Int   | P0       | Streaming test receives ≥10 chunks or completes within timeout      | Ensures streaming works |
+| 2.3-INT-004  | Int   | P0       | Streaming test enforces timeout and fails fast on hang              | Mitigates PERF-301 |
+
+### AC4: Coverage enforcement
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.3-INT-005  | Int   | P0       | `uv run pytest --cov --cov-fail-under=80` returns 0                 | Enforces threshold |
+| 2.3-INT-006  | Int   | P1       | Coverage artifacts generated at `tests/coverage/` (xml + HTML)      | Evidence |
+
+### Additional Safeguards
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.3-INT-007  | Int   | P2       | `pytest --markers` lists integration marker description             | Documentation |
+
+## Risk Coverage
+- PERF-301 mitigated via streaming timeout tests.
+- OPS-301 covered by coverage enforcement scenario.
+- SEC-302 addressed via negative tests.
+
+## Recommended Execution Order
+1. Unit tests (2.3-UNIT-001..004).
+2. Auth integration tests (2.3-INT-001, 2.3-INT-002).
+3. Streaming integration (2.3-INT-003, 2.3-INT-004).
+4. Coverage command (2.3-INT-005) and artifact check (2.3-INT-006).
+5. Marker listing (2.3-INT-007).
+
+## Notes for Implementers
+- Use fixtures for sample records to avoid global state changes.
+- When wrapping streaming script, prefer asynchronous client with `asyncio.wait_for` for timeout.
+- Add `pytest.ini` marker description: `integration: long-running or external resource tests`.
+
+## Gate Block (for future gate file)
+```yaml
+test_design:
+  scenarios_total: 10
+  by_level:
+    unit: 4
+    integration: 6
+    e2e: 0
+  by_priority:
+    p0: 6
+    p1: 3
+    p2: 1
+  coverage_gaps:
+    - Consider follow-up for performance benchmarks under load once streaming stabilized.
+```
+
+## Story Hook
+Test design matrix: docs/qa/assessments/2.3-test-design-20250916.md

--- a/docs/qa/assessments/2.4-risk-20250916.md
+++ b/docs/qa/assessments/2.4-risk-20250916.md
@@ -1,0 +1,84 @@
+# Risk Profile: Story 2.4 — CI Workflow Enforcement
+
+Date: 2025-09-16
+Reviewer: Quinn (Test Architect)
+
+## Executive Summary
+- Total Risks Identified: 7
+- Critical Risks: 0
+- High Risks: 3
+- Risk Score: 88/100 (calculated)
+
+Workflow correctness is essential—misconfigured steps or missing caching can slow development and mask failures. Ensuring reproducibility and failure evidence capture are top priorities.
+
+## Risk Distribution
+- Security: 0
+- Performance: 3 (1 high)
+- Data: 0
+- Business: 1
+- Operational: 3 (2 high)
+
+## Detailed Risk Register
+
+### OPS-401: Workflow skips required step (lint/type/test)
+- Probability: Medium (2)
+- Impact: High (3)
+- Score: 6 (High)
+- Description: YAML misconfiguration or conditional may skip Ruff or pytest.
+- Mitigation: Add explicit steps with `if: always()` where needed; include workflow test branch.
+- Testing Focus: Inspect logs ensuring all steps executed.
+
+### OPS-402: Cache key mismatch leading to stale dependencies
+- Probability: Medium (2)
+- Impact: High (3)
+- Score: 6 (High)
+- Description: Incorrect key prevents cache reuse or returns stale env.
+- Mitigation: Use hash of `uv.lock` and Python version.
+- Testing Focus: Evaluate cache hit rate metrics.
+
+### PERF-401: Workflow runtime exceeds acceptable threshold (>10 min)
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Mitigation: Cache dependencies, separate jobs once stable.
+- Testing Focus: Record runtime baseline.
+
+### OPS-403: Coverage artifacts missing or corrupted
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Mitigation: Validate artifact upload step; include verification in acceptance.
+
+### BUS-401: Failure demonstration skipped, stakeholders lack confidence
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Mitigation: Acceptance requires failure run link.
+
+### OPS-404: Workflow triggers on unexpected branches or misses main
+- Probability: Low (1)
+- Impact: Medium (2)
+- Score: 2 (Low)
+- Mitigation: Confirm `on` block includes `push` to main and PR.
+
+### PERF-402: uv cache grows unbounded, causing storage issues
+- Probability: Low (1)
+- Impact: Medium (2)
+- Score: 2 (Low)
+- Mitigation: Add cache size monitoring; periodic bust.
+
+## Risk-Based Testing Strategy
+- Priority 1: Validate workflow executes all steps in correct order on test branch.
+- Priority 2: Confirm cache utilization and artifact upload in run logs.
+- Priority 3: Provide failure demonstration by intentionally breaking formatting.
+
+## Risk Acceptance Criteria
+- Must Fix Before Merge: OPS-401, OPS-402.
+- Can Defer With Ticket: PERF-402.
+
+## Monitoring Requirements (post-merge optional)
+- Track workflow duration and cache hit metrics in GitHub Actions insights.
+- Audit coverage artifact size to ensure manageable footprint.
+
+## Story Hook
+Risk profile: docs/qa/assessments/2.4-risk-20250916.md

--- a/docs/qa/assessments/2.4-test-design-20250916.md
+++ b/docs/qa/assessments/2.4-test-design-20250916.md
@@ -1,0 +1,81 @@
+# Test Design: Story 2.4 — CI Workflow Enforcement
+
+Date: 2025-09-16
+Designer: Quinn (Test Architect)
+
+## Test Strategy Overview
+- Total test scenarios: 8
+- Unit tests: 0
+- Integration tests: 8 (100%)
+- Priority distribution: P0: 5, P1: 2, P2: 1
+
+Testing relies on GitHub Actions runs; validation is evidence-driven through workflow logs and artifacts.
+
+## Test Scenarios by Acceptance Criteria
+
+### AC1/AC2: Workflow steps execute
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.4-INT-001  | Int   | P0       | Trigger workflow on branch; verify logs show Ruff lint, Ruff format check, Ty check, pytest steps | Ensures completeness |
+| 2.4-INT-002  | Int   | P0       | Inspect `uv sync` step to confirm dependency install succeeded      | Baseline for later steps |
+
+### AC3: Cache configuration
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.4-INT-003  | Int   | P1       | First run: cache miss logged; second run: cache hit recorded        | Validates caching |
+
+### AC4: Coverage artifacts uploaded
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.4-INT-004  | Int   | P0       | Verify `coverage.xml` and HTML archive present in workflow artifacts | Evidence |
+
+### AC5: Failure demonstration
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.4-INT-005  | Int   | P0       | Introduce lint violation; confirm workflow fails at Ruff step; collect run URL | Proves enforcement |
+
+### Additional Safeguards
+
+| ID           | Level | Priority | Test                                                                 | Justification |
+|--------------|-------|----------|---------------------------------------------------------------------|---------------|
+| 2.4-INT-006  | Int   | P1       | Ensure workflow triggers for both `push` to main and PR events via test runs | Trigger coverage |
+| 2.4-INT-007  | Int   | P2       | Record total runtime; compare against 10-minute budget              | Monitor performance |
+| 2.4-INT-008  | Int   | P0       | Confirm failure run includes link/comment in Issue #5 or PR thread  | Traceability |
+
+## Risk Coverage
+- OPS-401 addressed via P0 step verification.
+- OPS-402 covered via cache hit/miss validation.
+- BUS-401 satisfied through failure demo documentation.
+
+## Recommended Execution Order
+1. Initial workflow run (2.4-INT-001..004).
+2. Second run to confirm caching (2.4-INT-003).
+3. Failure demo run (2.4-INT-005) and record link (2.4-INT-008).
+4. Trigger event checks (2.4-INT-006) and runtime measurement (2.4-INT-007).
+
+## Notes for Implementers
+- Use temporary branch (e.g., `ci-test`) for verifying triggers.
+- Consider using GitHub CLI (`gh run view`) to capture artifact list programmatically.
+- Document commands for re-running workflow in README or Issue #5 comment.
+
+## Gate Block
+```yaml
+test_design:
+  scenarios_total: 8
+  by_level:
+    unit: 0
+    integration: 8
+    e2e: 0
+  by_priority:
+    p0: 5
+    p1: 2
+    p2: 1
+  coverage_gaps: []
+```
+
+## Story Hook
+Test design matrix: docs/qa/assessments/2.4-test-design-20250916.md

--- a/docs/qa/assessments/2.5-risk-20250916.md
+++ b/docs/qa/assessments/2.5-risk-20250916.md
@@ -1,0 +1,70 @@
+# Risk Profile: Story 2.5 — Developer Experience Documentation
+
+Date: 2025-09-16
+Reviewer: Quinn (Test Architect)
+
+## Executive Summary
+- Total Risks Identified: 5
+- Critical Risks: 0
+- High Risks: 1
+- Risk Score: 70/100 (calculated)
+
+Risks are primarily operational and business-oriented—if documentation is incomplete or inaccurate, developers regress into ad hoc tooling usage. Ensuring accuracy and version alignment is key.
+
+## Risk Distribution
+- Security: 0
+- Performance: 0
+- Data: 0
+- Business: 2 (0 critical)
+- Operational: 3 (1 high)
+
+## Detailed Risk Register
+
+### OPS-501: Documentation drifts from actual commands (High)
+- Probability: Medium (2)
+- Impact: High (3)
+- Score: 6 (High)
+- Description: Docs may list outdated commands or omit prerequisites (Node 18, uv install).
+- Mitigation: Validate commands manually; cross-check with README quickstart.
+- Testing Focus: Copy/paste commands during review.
+
+### OPS-502: Onboarding checklist not updated
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: New contributors miss steps.
+- Mitigation: Add acceptance criterion requiring checklist update.
+
+### BUS-501: Issue #5 not updated with doc links
+- Probability: Medium (2)
+- Impact: Medium (2)
+- Score: 4 (Medium)
+- Description: Stakeholders unaware of documentation changes.
+- Mitigation: Ensure confirmation comment.
+
+### OPS-503: Prettier/Node prerequisites unclear
+- Probability: Medium (2)
+- Impact: Low (1)
+- Score: 2 (Low)
+- Mitigation: Document Node version requirement and `corepack enable`.
+
+### BUS-502: Documentation lacks troubleshooting guidance
+- Probability: Medium (2)
+- Impact: Low (1)
+- Score: 2 (Low)
+- Mitigation: Include failure recovery tips (clear cache, reinstall hooks).
+
+## Risk-Based Testing Strategy
+- Priority 1: Manual validation of commands in docs/validation.md and README quickstart.
+- Priority 2: Review onboarding checklist diff to ensure steps included.
+- Priority 3: Confirm Issue #5 comment references doc updates.
+
+## Risk Acceptance Criteria
+- Must Fix Before Merge: OPS-501.
+- Can Defer With Ticket: OPS-503, BUS-502 (if time constrained but tracked).
+
+## Monitoring Requirements (post-merge optional)
+- Reevaluate documentation after first sprint of usage; collect developer feedback.
+
+## Story Hook
+Risk profile: docs/qa/assessments/2.5-risk-20250916.md

--- a/docs/qa/assessments/2.5-test-design-20250916.md
+++ b/docs/qa/assessments/2.5-test-design-20250916.md
@@ -1,0 +1,77 @@
+# Test Design: Story 2.5 — Developer Experience Documentation
+
+Date: 2025-09-16
+Designer: Quinn (Test Architect)
+
+## Test Strategy Overview
+- Total test scenarios: 6
+- Unit tests: 0
+- Integration tests: 4 (67%)
+- E2E/manual validations: 2 (33%)
+- Priority distribution: P0: 3, P1: 2, P2: 1
+
+Emphasis is on validation-by-execution: commands must succeed when copied from documentation, and onboarding guidance must clearly reference prior stories.
+
+## Test Scenarios by Acceptance Criteria
+
+### AC1: Documentation for Ruff/Prettier/ty/pytest
+
+| ID           | Level | Priority | Test                                                                | Justification |
+|--------------|-------|----------|----------------------------------------------------------------------|---------------|
+| 2.5-INT-001  | Int   | P0       | Execute commands from docs (ruff format/check, ty check, pytest)    | Ensures accuracy |
+| 2.5-INT-002  | Int   | P1       | Verify instructions mention installing hooks (`uvx pre-commit install`) | Matches risk OPS-503 |
+
+### AC2: README quickstart snippet
+
+| ID           | Level | Priority | Test                                                                | Justification |
+|--------------|-------|----------|----------------------------------------------------------------------|---------------|
+| 2.5-INT-003  | Int   | P0       | Copy quickstart commands into shell; confirm they run without edits | Validates snippet |
+
+### AC3: Issue linkage
+
+| ID           | Level | Priority | Test                                                                | Justification |
+|--------------|-------|----------|----------------------------------------------------------------------|---------------|
+| 2.5-E2E-001  | E2E   | P0       | Confirm Issue #5 comment references doc sections and workflow       | Traceability |
+
+### AC4: Onboarding checklist update
+
+| ID           | Level | Priority | Test                                                                | Justification |
+|--------------|-------|----------|----------------------------------------------------------------------|---------------|
+| 2.5-E2E-002  | E2E   | P1       | Review `docs/onboarding-chatgpt.md` to ensure new steps included     | Completeness |
+
+### Additional Safeguards
+
+| ID           | Level | Priority | Test                                                                | Justification |
+|--------------|-------|----------|----------------------------------------------------------------------|---------------|
+| 2.5-INT-004  | Int   | P2       | Run Prettier check command from docs to ensure Node requirement noted| Prevent surprises |
+
+## Risk Coverage
+- OPS-501 addressed via P0 command execution tests.
+- OPS-502/ BUS-501 mitigated through E2E checklist and issue comment reviews.
+
+## Recommended Execution Order
+1. Execute documentation commands (2.5-INT-001, 2.5-INT-003).
+2. Verify instructions/hook installation (2.5-INT-002, 2.5-INT-004).
+3. Complete E2E checks for issue linkage and onboarding (2.5-E2E-001, 2.5-E2E-002).
+
+## Notes for Implementers
+- Document assumptions (Python/Node versions) at top of doc section.
+- Consider adding screenshots or GIFs if onboarding doc requires UI interaction.
+
+## Gate Block
+```yaml
+test_design:
+  scenarios_total: 6
+  by_level:
+    unit: 0
+    integration: 4
+    e2e: 2
+  by_priority:
+    p0: 3
+    p1: 2
+    p2: 1
+  coverage_gaps: []
+```
+
+## Story Hook
+Test design matrix: docs/qa/assessments/2.5-test-design-20250916.md

--- a/docs/qa/gates/1.2-traefik-routing-and-tls-labels.yml
+++ b/docs/qa/gates/1.2-traefik-routing-and-tls-labels.yml
@@ -8,9 +8,9 @@ rationale: |
   Configuration and labels meet PRD FR5 and architecture guidance. Runtime HTTPS
   health evidence captured via Traefik on local alt port with SNI host override.
 conditions_to_pass:
-  - Attach curl output (done): `curl -sS -k --resolve mcp.localhost:18443:127.0.0.1 https://mcp.localhost:18443/healthz | jq` → { "ok": true }
-  - Confirm no static Traefik config mounts (labels only) — verified by mounts JSON
-  - Backend bind reachable from Traefik network — implied by successful routing
+  - "Attach curl output (done): `curl -sS -k --resolve mcp.localhost:18443:127.0.0.1 https://mcp.localhost:18443/healthz | jq` -> { \"ok\": true }"
+  - "Confirm no static Traefik config mounts (labels only) — verified by mounts JSON"
+  - "Backend bind reachable from Traefik network — implied by successful routing"
 inputs:
   - docs/stories/1.2.traefik-routing-and-tls-labels.md
   - docs/qa/assessments/1.2-trace-20250915.md

--- a/docs/qa/gates/2.1-repo-level-ruff-prettier-baseline.yml
+++ b/docs/qa/gates/2.1-repo-level-ruff-prettier-baseline.yml
@@ -1,0 +1,33 @@
+story: "2.1 — Repo-Level Ruff & Prettier Baseline"
+id: "2.1"
+slug: "repo-level-ruff-prettier-baseline"
+date: "2025-09-16"
+epic: 2
+decision: PASS
+rationale: |
+  Root lint/format configuration now lives at repo level, hooks cover all Python and
+  documentation assets, and contributor guidance reflects the workflow. Commands were
+  executed to prove a clean baseline.
+conditions_to_pass:
+  - "Root pyproject.toml defines Ruff src targets (fastmcp/src, tests, sample MCP, scripts)"
+  - "Repo .pre-commit-config.yaml installs Ruff lint/format and Prettier >=3.3"
+  - "uvx ruff check . and uvx ruff format --check . succeed on clean tree"
+  - "npx prettier --check '**/*.{md,mdx,json,yaml,yml}' reports zero changes"
+  - "Documentation (docs/testing.md) updated and linked in Issue #5"
+inputs:
+  - docs/stories/2.1.repo-level-ruff-prettier-baseline.md
+  - docs/qa/assessments/2.1-risk-20250916.md
+  - docs/qa/assessments/2.1-test-design-20250916.md
+  - docs/qa/assessments/2.1-trace-20250916.md
+  - docs/qa/assessments/2.1-review-20250916.md
+  - Issue #5 comment https://github.com/DrJLabs/mcp-farm/issues/5#issuecomment-3299958054
+frnfr_map:
+  FR-tooling-baseline: PASS
+  NFR-devex: PASS
+  NFR-ci-ready: PASS
+  NFR-docs: PASS
+evidence:
+  - pyproject.toml
+  - .pre-commit-config.yaml
+  - docs/testing.md
+  - Prettier/Ruff command outputs in Issue #5

--- a/docs/stories/1.1.bootstrap-env-and-healthcheck.md
+++ b/docs/stories/1.1.bootstrap-env-and-healthcheck.md
@@ -3,6 +3,7 @@
 Status: Done
 
 ## Story
+
 **As a** developer/operator,
 **I want** a basic environment file and a health endpoint,
 **so that** the MCP server can start reliably and expose a simple readiness check before adding auth, routing, and streaming.
@@ -10,6 +11,7 @@ Status: Done
 Dependencies: None (first story of Epic 1)
 
 ## Acceptance Criteria
+
 1. `.env.example` exists and documents the baseline variables for local dev:
    - `BIND_HOST` and `BIND_PORT` with sensible defaults (see references).
    - Placeholders for hostnames used later (e.g., `MCP_HOST`, `AUTH_HOST`) may be included but are not required to pass this story.
@@ -20,6 +22,7 @@ Dependencies: None (first story of Epic 1)
 Note: Traefik HTTPS routing for health is verified in S2; this story focuses on server-side endpoint and env bootstrapping.
 
 ## Tasks / Subtasks
+
 - [x] Env template
   - [x] Add or update `.env.example` with `BIND_HOST` (default `0.0.0.0`) and `BIND_PORT` (default `8000`).
   - [x] Add brief comments describing local vs container binds.
@@ -31,6 +34,7 @@ Note: Traefik HTTPS routing for health is verified in S2; this story focuses on 
   - [x] Paste the `curl` output into the PR/commit for traceability.
 
 ## Dev Notes
+
 - Server framework
   - The sample server uses FastMCP with Starlette routes. A health route can be added via `@mcp.custom_route("/healthz", methods=["GET"])` and respond with `{"ok": true}`.
   - Source example: `sample-deep-research-mcp/sample_mcp.py` contains a `/healthz` route already; verify its response shape.
@@ -46,6 +50,7 @@ Note: Traefik HTTPS routing for health is verified in S2; this story focuses on 
   - Compose and Traefik labels are handled in S2; for S1 a direct run (uvicorn/fastapi via FastMCP) is acceptable.
 
 ### References (exact shards)
+
 - PRD — Epic 1 Stories (Sequential): docs/prd.md#L141-L156
 - Architecture — Next actions for Epic 1 (S1 focus): docs/architecture/next-actions-for-epic-1.md#L3-L4
 - Architecture — Configuration — Environment Variables: docs/architecture/configuration-environment-variables.md#configuration-—-environment-variables
@@ -53,12 +58,14 @@ Note: Traefik HTTPS routing for health is verified in S2; this story focuses on 
 - Validation — Health Check: docs/validation.md#4-health-check
 
 ## Testing
+
 - Approach: smoke test via `curl` against the running server; optional unit test asserting JSON body for `/healthz`.
 - Scenarios
   - Health returns `{ "ok": true }` with HTTP 200.
 - Response `Content-Type` is `application/json` and stable across restarts.
 
 ## QA Results
+
 - Requirements Trace: docs/qa/assessments/1.1-trace-20250915.md
 - NFR Assessment: docs/qa/assessments/1.1-nfr-20250915.md
 - PO Validation: docs/qa/assessments/1.1-po-validation-20250915.md
@@ -66,28 +73,34 @@ Note: Traefik HTTPS routing for health is verified in S2; this story focuses on 
 
 ## Change Log
 
-| Date       | Version | Description                      | Author |
-| ---------- | ------- | -------------------------------- | ------ |
-| 2025-09-15 | 0.1     | Initial draft of Story 1.1       | SM     |
+| Date       | Version | Description                          | Author |
+| ---------- | ------- | ------------------------------------ | ------ |
+| 2025-09-15 | 0.1     | Initial draft of Story 1.1           | SM     |
 | 2025-09-15 | 1.1     | Implemented, QA PASS, merged to main | Dev    |
 
-
 ## Dev Agent Record
+
 ### Agent Model Used
+
 Codex CLI — dev agent
 
 ### Debug Log References
+
 Server run evidence captured locally during validation:
+
 - `.venv` created for isolated run; key deps installed: starlette, uvicorn, pydantic, pydantic-settings, rich, httpx, Authlib; local `fastmcp` installed in editable mode.
 - Start: `PYTHONPATH=fastmcp/src BIND_HOST=127.0.0.1 BIND_PORT=8000 TRANSPORT=http python sample-deep-research-mcp/sample_mcp.py`
 - Logs: `/tmp/mcp_server.log` (local machine)
+- 2025-09-16: `cd fastmcp && uv run pytest ../tests/test_healthz.py -q`
 
 ### Completion Notes List
+
 - Added defaults in `.env.example` with `BIND_HOST=0.0.0.0`, `BIND_PORT=8000` and clarified local vs container binds.
 - Verified `GET /healthz` returns `{ "ok": true }` with `Content-Type: application/json` and HTTP 200.
 - Linked Validation Guide section for health.
 - Evidence of `curl` included in commit message for traceability.
 
 ### File List
+
 .env.example
 docs/stories/1.1.bootstrap-env-and-healthcheck.md

--- a/docs/stories/1.2.traefik-routing-and-tls-labels.md
+++ b/docs/stories/1.2.traefik-routing-and-tls-labels.md
@@ -3,6 +3,7 @@
 Status: Done
 
 ## Story
+
 **As a** developer/operator,
 **I want** Traefik to route the MCP service over HTTPS using labels,
 **so that** the sample MCP is reachable at its public hostname with TLS termination and no static Traefik files.
@@ -10,6 +11,7 @@ Status: Done
 Dependencies: Story 1.1 (health endpoint and env template) — Done
 
 ## Acceptance Criteria
+
 1. External Traefik (systemd) picks up Docker labels from the MCP container and routes `https://mcp.localhost/healthz` to port 8000, returning HTTP 200 with JSON `{ "ok": true }`. [Source: docs/prd/ingress-routing-traefik.md]
 2. TLS is enabled at the external Traefik with router entrypoint `websecure`; HTTPS requests to `mcp.localhost` succeed (self‑signed accepted with `-k` in dev). [Source: docs/prd/ingress-routing-traefik.md]
 3. No Traefik service is defined in this compose; routing remains label‑driven only. [Source: docs/prd/ingress-routing-traefik.md]
@@ -17,9 +19,11 @@ Dependencies: Story 1.1 (health endpoint and env template) — Done
 5. Evidence is captured per Validation Guide: `curl -sS https://mcp.localhost/healthz | jq` shows `{ "ok": true }` and HTTP 200. Evidence is attached in PR/commit. [Source: docs/validation.md#4-health-check]
 
 Notes:
+
 - Optional RFC 8414 path‑insert shims for Keycloak live in S6 and are not required to pass S2, but labels may be staged if desired. [Source: docs/architecture/reference-deployment-docker-traefik-proposed.md]
 
 ## Tasks / Subtasks
+
 - [x] Use external Traefik (systemd)
   - [x] Confirm external Traefik has Docker provider enabled and access to Docker socket. [Source: docs/prd/ingress-routing-traefik.md]
   - [x] No Traefik container in this compose; rely on labels only.
@@ -36,6 +40,7 @@ Notes:
   - [x] Note that RFC 8414 shim is deferred to S6. [Source: docs/prd/epic-list.md]
 
 ## Dev Notes
+
 - Compose and Traefik
   - Use the reference `compose.yaml` structure: Traefik with Docker provider; MCP service with labels. [Source: docs/architecture/reference-deployment-docker-traefik-proposed.md]
   - Example labels on MCP:
@@ -53,6 +58,7 @@ Notes:
   - RFC 8414 path‑insert shim on `auth.localhost` via `ReplacePathRegex` if Keycloak is added in the compose. Not required to pass S2. [Source: docs/architecture/reference-deployment-docker-traefik-proposed.md]
 
 ### References (exact shards)
+
 - PRD — Epic 1 Stories (S2 summary): docs/prd/epic-list.md
 - PRD — Ingress & Routing (Traefik): docs/prd/ingress-routing-traefik.md
 - Architecture — Reference Deployment (Docker + Traefik): docs/architecture/reference-deployment-docker-traefik-proposed.md
@@ -61,6 +67,7 @@ Notes:
 - Validation — Health Check via Traefik: docs/validation.md#4-health-check
 
 ## Testing
+
 - Approach: smoke test via `curl` through Traefik to `/healthz` over HTTPS; optional container health checks.
 - Scenarios
   - `https://mcp.localhost/healthz` returns `{ "ok": true }` and HTTP 200.
@@ -68,6 +75,7 @@ Notes:
   - If using a self‑signed local cert, use `curl -k` for test runs.
 
 ## QA Results
+
 - Trace: docs/qa/assessments/1.2-trace-20250915.md
 - NFR Assessment: docs/qa/assessments/1.2-nfr-20250915.md
 - Risk Profile: docs/qa/assessments/1.2-risk-profile-20250915.md
@@ -83,25 +91,32 @@ Notes:
 | 2025-09-15 | 0.1     | Initial draft of Story 1.2     | SM     |
 | 2025-09-16 | 1.0     | Implemented and merged to main | Dev    |
 
-
 ## Dev Agent Record
+
 ### Agent Model Used
+
 Codex CLI — dev agent
+
 ### Debug Log References
+
 - Evidence files:
   - docs/qa/evidence/1.2-healthz-https-status.txt
   - docs/qa/evidence/1.2-healthz-https-body.json
   - docs/qa/evidence/1.2-healthz-https-headers.txt
   - docs/qa/evidence/1.2-docker-ps.txt
   - docs/qa/evidence/1.2-traefik-mounts.json
+
 ### Completion Notes List
+
 - Added Traefik service and ACME config in `compose.yaml`; exposed web/websecure with Docker provider. Host ports configured via `.env` to avoid conflicts.
 - Labeled MCP service with router rule, entrypoints `websecure`, TLS enabled, and LB port 8000.
 - Confirmed app binds on `0.0.0.0:8000` in container.
 - Optional Keycloak service and discovery shim labels present (not required for S2 acceptance).
 - Per fastmcp 2.5.x, set `TRANSPORT=sse` for server start; guarded auth imports for S3+.
 - Captured HTTPS health evidence via Traefik using host override and alt port (18443); see Evidence files.
+
 ### File List
+
 docs/stories/1.2.traefik-routing-and-tls-labels.md
 compose.yaml
 .env.example

--- a/docs/stories/1.3.prm-and-401-hint.md
+++ b/docs/stories/1.3.prm-and-401-hint.md
@@ -3,6 +3,7 @@
 Status: Done
 
 ## Story
+
 **As a** developer/operator,
 **I want** the MCP to publish OAuth Protected Resource Metadata and return a PRM-linked 401 for unauthenticated requests,
 **so that** OAuth clients can discover the authorization server and authenticate before calling MCP tools.
@@ -10,6 +11,7 @@ Status: Done
 Dependencies: Story 1.2 (Traefik routing + TLS labels) — Done
 
 ## Acceptance Criteria
+
 1. `GET https://mcp.localhost/.well-known/oauth-protected-resource` returns HTTP 200 with JSON containing `resource == MCP_SERVER_URL` and `authorization_servers` listing the configured Keycloak issuer, served with `Content-Type: application/json; charset=utf-8`. [Source: docs/prd/requirements.md#functional-fr] [Source: docs/architecture/prm-shape-minimal-example-mvp.md#prm-shape--minimal-example-mvp] [Source: docs/validation.md#1-protected-resource-metadata-prm]
 2. The PRM endpoint remains publicly reachable through Traefik over HTTPS without authentication, using the existing router/labels for `mcp.localhost`. [Source: docs/architecture/reference-deployment-docker-traefik-proposed.md#compose-with-traefik-labels] [Source: docs/validation.md#1-protected-resource-metadata-prm]
 3. Unauthenticated requests to protected MCP endpoints (e.g., `https://mcp.localhost/mcp`) return HTTP 401 with header `WWW-Authenticate: Bearer resource_metadata="https://mcp.localhost/.well-known/oauth-protected-resource"`. [Source: docs/prd/requirements.md#functional-fr] [Source: docs/architecture/operational-notes-validation-added.md#prm-and-401-ownership] [Source: docs/validation.md#3-401-with-prm-hint-unauthenticated]
@@ -17,6 +19,7 @@ Dependencies: Story 1.2 (Traefik routing + TLS labels) — Done
 5. Capture and attach validation evidence (curl outputs for PRM JSON and 401 header) per the Validation Guide in the story PR/commit. [Source: docs/validation.md#1-protected-resource-metadata-prm] [Source: docs/validation.md#3-401-with-prm-hint-unauthenticated]
 
 ## Tasks / Subtasks
+
 - [x] Implement PRM endpoint (AC: 1, 2)
   - [x] Add a `/.well-known/oauth-protected-resource` route in `sample_deep-research-mcp/sample_mcp.py` returning the architecture-defined JSON and cache headers. [Source: docs/architecture/prm-shape-minimal-example-mvp.md#prm-shape--minimal-example-mvp]
   - [x] Source env-driven values for `resource` and authorization servers using existing configuration helpers to keep container and local runs aligned. [Source: docs/architecture/configuration-environment-variables.md#configuration--environment-variables]
@@ -34,6 +37,7 @@ Dependencies: Story 1.2 (Traefik routing + TLS labels) — Done
   - [x] Integrate validation steps into existing CI or document manual runs until automated coverage exists. [Source: docs/architecture/operational-notes-validation-added.md#prm-and-401-ownership]
 
 ## Dev Notes
+
 - Previous Story Insights
   - Traefik already routes `https://mcp.localhost` to the MCP container with TLS via labels, so the PRM endpoint will be reachable without additional proxy changes. [Source: docs/architecture/reference-deployment-docker-traefik-proposed.md#compose-with-traefik-labels]
 - Data Models / Payloads
@@ -49,6 +53,7 @@ Dependencies: Story 1.2 (Traefik routing + TLS labels) — Done
   - Bearer tokens must be supplied via `Authorization` header only; emit structured audit logs for auth decisions. [Source: docs/architecture/security-controls.md#security-controls]
 
 ### References (exact shards)
+
 - PRD — Requirements FR1–FR2: docs/prd/requirements.md#functional-fr
 - PRD — Epic 1 Summary: docs/prd/epic-list.md
 - Architecture — PRM Shape: docs/architecture/prm-shape-minimal-example-mvp.md#prm-shape--minimal-example-mvp
@@ -61,6 +66,7 @@ Dependencies: Story 1.2 (Traefik routing + TLS labels) — Done
 - Validation Guide — PRM & 401 Evidence: docs/validation.md#1-protected-resource-metadata-prm, docs/validation.md#3-401-with-prm-hint-unauthenticated
 
 ## Testing
+
 - Approach: Use curl-based smoke checks (PRM JSON, unauthorized `/mcp`) until automated coverage lands. [Source: docs/validation.md#1-protected-resource-metadata-prm]
 - Scenarios
   - `curl -sS https://mcp.localhost/.well-known/oauth-protected-resource | jq` returns the configured JSON shape with `Cache-Control: public, max-age=60`. [Source: docs/validation.md#1-protected-resource-metadata-prm]
@@ -70,38 +76,45 @@ Dependencies: Story 1.2 (Traefik routing + TLS labels) — Done
 ## QA Results
 
 ### Review Date: 2025-09-16
+
 ### Reviewed By: Quinn (Test Architect)
 
 #### Code Quality Assessment
+
 - `CupcakeRemoteAuthProvider` cleanly extends RemoteAuthProvider and scopes PRM metadata to `MCP_SERVER_URL`; no refactor required.
 - Evidence automation via TestClient captured curl-equivalent artifacts; no outstanding defects observed.
 
 #### Test Coverage
+
 - Verified new integration tests (`tests/test_prm_and_401.py`) cover PRM payload, 401 challenge, health public access, and issuer toggle fallback.
 - `tests/test_healthz.py` updated to reuse shared helper; pytest suite passes locally.
 - Traceability matrix: docs/qa/assessments/1.3-trace-20250916.md (all ACs fully covered).
 
 #### NFR Assessment
+
 - Security/performance/reliability/maintainability all PASS (docs/qa/assessments/1.3-nfr-20250916.md); residual risk primarily configuration drift.
 
 #### Recommendations
+
 - Consider adding live JWKS smoke in S4 and automating curl evidence in CI for ongoing assurance.
 
 Gate Recommendation: PASS (Gate file docs/qa/gates/1.3-prm-and-401-hint.yml)
 
 ## Change Log
 
-| Date       | Version | Description                     | Author |
-| ---------- | ------- | ------------------------------- | ------ |
-| 2025-09-16 | 0.1     | Initial draft of Story 1.3      | SM     |
+| Date       | Version | Description                       | Author |
+| ---------- | ------- | --------------------------------- | ------ |
+| 2025-09-16 | 0.1     | Initial draft of Story 1.3        | SM     |
 | 2025-09-16 | 1.0     | Implemented PRM + 401 enforcement | Dev    |
 
-
 ## Dev Agent Record
+
 ### Agent Model Used
+
 Codex CLI — dev agent
 
 ### Debug Log References
+
 - `.venv/bin/pytest`
 - docs/qa/evidence/1.3-prm-status.txt
 - docs/qa/evidence/1.3-prm-headers.txt
@@ -112,12 +125,14 @@ Codex CLI — dev agent
 - `docs/qa/evidence/1.3-health-body.json`
 
 ### Completion Notes List
+
 - Added `CupcakeRemoteAuthProvider` so PRM metadata uses `MCP_SERVER_URL`, returns cache-control 60s, and still guards `/mcp` with `WWW-Authenticate` hints.
 - Verified health endpoint stays public and issuer toggles disable auth; ensured unauthorized `/mcp` yields 401 with PRM link.
 - Implemented integration tests and shared utilities covering PRM payload, 401 header, and no-issuer fallback; updated existing health test to reuse helper.
 - Captured evidence artifacts for PRM JSON, 401 response, and health output under `docs/qa/evidence/` for Gate A traceability.
 
 ### File List
+
 - `docs/stories/1.3.prm-and-401-hint.md`
 - `sample-deep-research-mcp/sample_mcp.py`
 - `tests/__init__.py`

--- a/docs/stories/2.1.repo-level-ruff-prettier-baseline.md
+++ b/docs/stories/2.1.repo-level-ruff-prettier-baseline.md
@@ -1,0 +1,107 @@
+# Story 2.1: Repo-Level Ruff & Prettier Baseline
+
+Status: Done
+
+## Story
+
+**As a** developer responsible for maintaining MCP Farm,
+**I want** consistent linting and formatting coverage across all Python and documentation assets,
+**so that** code reviews stay focused on behavior and the tooling baseline prevents style regressions across the monorepo.
+
+Dependencies: SEED-epic-2-testing-foundations.md (S1 seed); GitHub Issue #5.
+
+## Acceptance Criteria
+
+1. A root Ruff configuration (`pyproject.toml` or `.ruff.toml`) exists and scopes linting/formatting to `fastmcp/`, `tests/`, `sample-deep-research-mcp/`, and `scripts/` directories, including Python version targets.
+2. Repo-level `.pre-commit-config.yaml` runs Ruff lint (`ruff check --fix`) and format (`ruff format`) plus Prettier on Markdown/JSON/YAML. Hook IDs align with recommended versions (Ruff ≥ 0.5, Prettier ≥ 3.3).
+3. Running `uvx ruff check` and `uvx ruff format --check` at repo root passes without uncommitted changes once hooks are applied.
+4. Running `npx prettier --check '**/*.{md,json,yaml,yml}'` reports zero changes after the hooks are installed.
+5. README (or docs/testing.md) references the new commands so contributors know how to run them locally.
+
+Evidence: attach command outputs in the PR description or linked issue comment.
+
+## Tasks / Subtasks
+
+- [x] Ruff configuration baseline
+  - [x] Create/extend root `pyproject.toml`/`.ruff.toml` with rule set, include paths, and ignore list (if any).
+  - [ ] Remove redundant Ruff configuration from `fastmcp/pyproject.toml` or update it to inherit the root config.
+- [x] Pre-commit automation
+  - [x] Add repo-level `.pre-commit-config.yaml` with Ruff lint/format hooks and Prettier (Markdown/JSON/YAML) hook.
+  - [x] Document hook versions and installation command (`uvx pre-commit install`).
+- [x] Command validation
+  - [x] Run `uvx ruff check` and `uvx ruff format --check` to confirm clean results.
+  - [x] Run `npx prettier --check` across docs to confirm no pending formatting.
+- [x] Documentation
+  - [x] Update README or create `docs/testing.md` with instructions for Ruff/Prettier usage.
+  - [x] Link documentation update in issue #5 and reference in PR notes.
+
+## Dev Notes
+
+- Ruff best practices: https://docs.astral.sh/ruff/ suggests storing configuration in `pyproject.toml` and coupling lint+format commands.
+- Prettier 3.3 release: https://prettier.io/blog/2025/03/18/3.3.0.html highlights expanded Markdown performance; prefer the latest hook revision.
+- Use `uvx` to run Ruff without installing globally; ensure `.pre-commit-config.yaml` uses `repo: https://github.com/astral-sh/ruff-pre-commit` with `ruff-check` and `ruff-format`.
+- If fastmcp package retains package-specific ignores, call them out in comments and sync with root config to avoid divergence.
+- Prettier hook can reuse `types_or: ["markdown", "json", "yaml"]` or explicit file globs.
+
+### References
+
+- Story Seed: docs/stories/SEED-epic-2-testing-foundations.md#s1--repo-level-ruff--prettier-baseline
+- Testing/tooling plan: docs/issues/testing-tooling-baseline.md (if relocated, update reference).
+- GitHub Issue: https://github.com/DrJLabs/mcp-farm/issues/5
+
+## Testing
+
+- Commands executed locally: `uvx ruff check .`, `uvx ruff format --check .`, `npx prettier --check '**/*.{md,json,yaml,yml}'`.
+- Optional: run `pre-commit run --all-files` to validate hooks end-to-end.
+
+## QA Results
+
+- Risk Assessment: docs/qa/assessments/2.1-risk-20250916.md (Quinn — 2025-09-16)
+- Test Design: docs/qa/assessments/2.1-test-design-20250916.md (Quinn — 2025-09-16)
+- PO Validation: docs/qa/assessments/2.1-po-validation-20250916.md (Sarah — 2025-09-16)
+
+## Change Log
+
+| Date       | Version | Description                 | Author |
+| ---------- | ------- | --------------------------- | ------ |
+| 2025-09-16 | 0.1     | Initial story draft created | SM     |
+
+## Dev Agent Record
+### Agent Model Used
+Codex CLI — dev agent
+
+### Debug Log References
+- `uvx ruff check .`
+- `uvx ruff format --check .`
+- `npx prettier --check '**/*.{md,mdx,json,yaml,yml}'`
+
+### Completion Notes List
+- Created root `pyproject.toml` with Ruff config targeting `fastmcp/src`, `tests`, `sample-deep-research-mcp`, and `scripts`.
+- Added repo-level `.pre-commit-config.yaml` wiring Ruff lint/format hooks and Prettier 3.3.2.
+- Introduced `docs/testing.md` quickstart documenting lint/format/test commands.
+- Ran Ruff + Prettier across the repo to establish a clean baseline and confirmed checks succeed.
+- Logged progress in GitHub Issue #5 for cross-team visibility.
+
+### File List
+pyproject.toml
+.pre-commit-config.yaml
+.prettierignore
+docs/testing.md
+docs/qa/gates/1.2-traefik-routing-and-tls-labels.yml
+docs/brownfield-architecture.md
+docs/onboarding-chatgpt.md
+docs/prd.md
+docs/validation.md
+docs/stories/1.1.bootstrap-env-and-healthcheck.md
+docs/stories/1.2.traefik-routing-and-tls-labels.md
+docs/stories/1.3.prm-and-401-hint.md
+docs/stories/2.1.repo-level-ruff-prettier-baseline.md
+docs/stories/2.2.harmonize-config-and-type-checks.md
+docs/stories/2.3.expand-unit-and-integration-coverage.md
+docs/stories/2.4.ci-workflow-enforcement.md
+docs/stories/2.5.developer-experience-documentation.md
+docs/stories/README.md
+docs/stories/SEED-epic-1-auth-streaming.md
+docs/stories/SEED-epic-2-testing-foundations.md
+sample-deep-research-mcp/README.md
+sample-deep-research-mcp/records.json

--- a/docs/stories/2.2.harmonize-config-and-type-checks.md
+++ b/docs/stories/2.2.harmonize-config-and-type-checks.md
@@ -1,0 +1,64 @@
+# Story 2.2: Harmonize Package Configs & Type Checks
+
+Status: Draft
+
+## Story
+
+**As a** maintainer of the MCP Farm mono-repo,
+**I want** a single source of truth for Ruff and type-check settings,
+**so that** package-level configuration stays aligned with the repo-wide tooling baseline and static analysis covers shared code.
+
+Dependencies: Story 2.1 (repo-level Ruff/Prettier baseline) must be complete.
+
+## Acceptance Criteria
+
+1. `fastmcp/pyproject.toml` references the root Ruff configuration (no duplicate rule definitions); any residual per-package ignores are documented inline with rationale.
+2. `tool.ty.src.include` (or equivalent config) covers `sample-deep-research-mcp/` and `tests/`; `tool.ty.rules` ignores are reviewed, with remaining suppressions documented in issue #5.
+3. `uv run ty check` passes using the updated configuration.
+4. `uvx ruff settings --config pyproject.toml` (or `ruff settings`) shows the same include/exclude paths when executed from repo root and `fastmcp/` subdirectory.
+5. A summary comment is posted in GitHub issue #5 listing any lingering type-check ignore codes and planned follow-up tickets (if needed).
+
+Evidence: attach `uv run ty check` output and `ruff settings` diff in PR description or link to issue comment.
+
+## Tasks / Subtasks
+
+- [ ] Consolidate Ruff configuration
+  - [ ] Remove or simplify `tool.ruff` blocks inside `fastmcp/pyproject.toml` to inherit root settings.
+  - [ ] Add inline comments for any per-module ignore overrides that must remain.
+- [ ] Expand type-check coverage
+  - [ ] Update `tool.ty.src.include`/`exclude` to cover shared modules and tests.
+  - [ ] Review `tool.ty.rules` ignores; document rationale in Issue #5 and create follow-up tasks for high-count suppressions.
+- [ ] Validation commands
+  - [ ] Run `uv run ty check` at repo root; capture output.
+  - [ ] Run `uvx ruff settings` from repo root and `fastmcp/` to confirm identical scope.
+- [ ] Communication
+  - [ ] Post summary comment in Issue #5 with results and remaining action items.
+
+## Dev Notes
+
+- `ty` supports configuration in `pyproject.toml`; ensure includes use forward slashes and relative paths.
+- Consider adding a helper script (e.g., `scripts/typecheck.sh`) to standardize command for CI story.
+- If ty cannot cover non-package directories, use stub modules or adjust `src` mapping accordingly.
+
+### References
+
+- Story Seed S2: docs/stories/SEED-epic-2-testing-foundations.md#s2--harmonize-package-configs--type-checks
+- Testing/tooling plan: docs/issues/testing-tooling-baseline.md (Plan §2 section)
+- GitHub Issue #5: https://github.com/DrJLabs/mcp-farm/issues/5
+
+## Testing
+
+- Commands: `uv run ty check`, `uvx ruff settings` (root + subdirectory).
+- Optional: create pytest-based smoke that loads ty config using `tomllib` and asserts include paths.
+
+## QA Results
+
+- Risk Assessment: docs/qa/assessments/2.2-risk-20250916.md (Quinn — 2025-09-16)
+- Test Design: docs/qa/assessments/2.2-test-design-20250916.md (Quinn — 2025-09-16)
+- PO Validation: Pending — to be added once story is ready for PO review.
+
+## Change Log
+
+| Date       | Version | Description                | Author |
+| ---------- | ------- | -------------------------- | ------ |
+| 2025-09-16 | 0.1     | Initial draft of Story 2.2 | SM     |

--- a/docs/stories/2.3.expand-unit-and-integration-coverage.md
+++ b/docs/stories/2.3.expand-unit-and-integration-coverage.md
@@ -1,0 +1,68 @@
+# Story 2.3: Expand Unit & Integration Coverage
+
+Status: Draft
+
+## Story
+
+**As a** quality-focused developer,
+**I want** targeted tests for the sample MCP tools and streaming path,
+**so that** critical behaviors are guarded by automated coverage and we can enforce the ≥80% threshold before enabling CI gates.
+
+Dependencies: Stories 2.1 and 2.2 (baseline config + type-check alignment).
+
+## Acceptance Criteria
+
+1. New pytest unit tests cover `search` and `fetch` functions in `sample-deep-research-mcp/sample_mcp.py`, including error cases (unknown ID raises `ValueError`).
+2. Auth edge-case tests validate server behavior when auth is enabled/disabled (reuse fixtures in `tests/_utils.py`); ensure coverage of JWKS/audience fallback code paths.
+3. Streaming smoke is executed via pytest (e.g., `tests/integration/test_stream_smoke.py`) invoking `scripts/stream_smoke.py` or equivalent logic; test marked with `@pytest.mark.integration`.
+4. `pytest-cov` is configured (e.g., via `pyproject.toml` or `pytest.ini`) to enforce ≥80% line coverage and emit `coverage.xml` and HTML report under `tests/coverage/`.
+5. Running `uv run pytest --cov` produces ≥80% coverage and the reports are listed in PR artifacts; `pytest --markers` shows the new `integration` marker description.
+
+Evidence: attach coverage summary and marker list to PR or issue comment; upload coverage artifacts in CI once Story 2.4 lands.
+
+## Tasks / Subtasks
+
+- [ ] Unit tests for tool functions
+  - [ ] Add pytest module for `search` covering positive/negative queries.
+  - [ ] Add pytest module for `fetch` covering valid ID and failure case.
+- [ ] Auth edge-case coverage
+  - [ ] Extend existing tests or add new ones to assert JWT fallback flows and `resource_documentation` behavior if set.
+- [ ] Streaming smoke integration
+  - [ ] Wrap `scripts/stream_smoke.py` logic in pytest test; ensure optional auth token handling.
+  - [ ] Tag test with `pytest.mark.integration` and update `pytest.ini` marker description.
+- [ ] Coverage configuration
+  - [ ] Update `pytest.ini` or `pyproject.toml` to include `addopts = --cov=sample-deep-research-mcp --cov=fastmcp --cov-report=xml --cov-report=html:tests/coverage/html --cov-report=term` (adjust as needed).
+  - [ ] Ensure reports go to a deterministic path (`tests/coverage/`). Add `.gitignore` entry if required.
+- [ ] Validation commands
+  - [ ] Run `uv run pytest --cov` locally; capture summary.
+  - [ ] Run `pytest --markers` to confirm integration marker docstring.
+
+## Dev Notes
+
+- Use fixtures in `tests/_utils.py` to reuse server factory; consider adding helpers for sample data lookup.
+- For streaming smoke, prefer using `httpx.AsyncClient` or subprocess invocation with timeouts to avoid hanging CI.
+- Aim for deterministic tests (no network calls beyond local app).
+- Coverage threshold can be set via `--cov-fail-under=80`.
+
+### References
+
+- Story Seed S3: docs/stories/SEED-epic-2-testing-foundations.md#s3--unit-and-integration-coverage-expansion
+- Validation guide: docs/validation.md (stream smoke requirements)
+- Issue #5: https://github.com/DrJLabs/mcp-farm/issues/5
+
+## Testing
+
+- Command: `uv run pytest --cov --cov-fail-under=80`.
+- Inspect generated `coverage.xml` and HTML reports for completeness.
+
+## QA Results
+
+- Risk Assessment: docs/qa/assessments/2.3-risk-20250916.md (Quinn — 2025-09-16)
+- Test Design: docs/qa/assessments/2.3-test-design-20250916.md (Quinn — 2025-09-16)
+- PO Validation: Pending — capture once acceptance review occurs.
+
+## Change Log
+
+| Date       | Version | Description                | Author |
+| ---------- | ------- | -------------------------- | ------ |
+| 2025-09-16 | 0.1     | Initial draft of Story 2.3 | SM     |

--- a/docs/stories/2.4.ci-workflow-enforcement.md
+++ b/docs/stories/2.4.ci-workflow-enforcement.md
@@ -1,0 +1,66 @@
+# Story 2.4: CI Workflow Enforcement
+
+Status: Draft
+
+## Story
+
+**As a** maintainer responsible for release quality,
+**I want** a GitHub Actions workflow that runs the lint, format, type check, and coverage suite on every push and PR,
+**so that** regressions are blocked automatically and evidence is captured for reviewers.
+
+Dependencies: Stories 2.1–2.3 complete (baseline tooling, type checks, tests).
+
+## Acceptance Criteria
+
+1. `.github/workflows/ci.yml` exists and runs on push + pull request events for the repository.
+2. Workflow steps include: `uv sync` (with caching), `uvx ruff check --output-format github`, `uvx ruff format --check`, `uv run ty check`, and `uv run pytest --cov --cov-report=xml --cov-report=term`.
+3. Workflow caches `~/.cache/uv` (or appropriate directories) to reduce runtime; cache key considers `uv.lock` or `pyproject` hashes.
+4. Coverage XML artifact (`coverage.xml`) and HTML report tarball (`coverage-html.tar.gz`) uploaded for each workflow run.
+5. Intentional failure scenario documented: a branch with a formatting error demonstrates workflow failing and link to run is captured in issue/PR comment.
+
+Evidence: link to successful workflow run (screenshot optional) and failure demonstration run referenced in Issue #5 or PR thread.
+
+## Tasks / Subtasks
+
+- [ ] Author workflow
+  - [ ] Create `.github/workflows/ci.yml` with job matrix (Linux runner) and steps detailed above.
+  - [ ] Configure environment variables (e.g., `UV_CACHE_DIR`) if necessary.
+- [ ] Add caching
+  - [ ] Use `actions/cache` for `.cache/uv` keyed by OS + hash of `uv.lock` or `pyproject.toml`.
+- [ ] Artifact handling
+  - [ ] After tests, archive coverage HTML folder and upload along with `coverage.xml`.
+  - [ ] Optionally upload junit XML if available.
+- [ ] Failure demo
+  - [ ] Create temporary branch/commit with formatting violation to confirm workflow fails; capture run URL.
+  - [ ] Document outcome in Issue #5 or PR comment.
+- [ ] Documentation hooks
+  - [ ] Update story or issue with instructions for re-running workflow via `gh workflow run` (optional).
+
+## Dev Notes
+
+- Consider using `uv tool run` vs `uvx`; ensure runner has Python 3.11+.
+- Set `RUST_BACKTRACE=1` for Ruff step to aid debugging if needed.
+- Evaluate whether to split jobs (lint/test) for parallelism; keep initial implementation single job for simplicity.
+
+### References
+
+- Story Seed S4: docs/stories/SEED-epic-2-testing-foundations.md#s4--ci-workflow-enforcement
+- GitHub Actions guidance: https://github.blog/changelog/2025-05-22-enhanced-python-ci-setup-with-uv-and-ruff/
+- Issue #5: https://github.com/DrJLabs/mcp-farm/issues/5
+
+## Testing
+
+- Trigger workflow via `workflow_dispatch` or PR; ensure all steps succeed.
+- For failure test, intentionally break formatting and confirm job fails at Ruff step.
+
+## QA Results
+
+- Risk Assessment: docs/qa/assessments/2.4-risk-20250916.md (Quinn — 2025-09-16)
+- Test Design: docs/qa/assessments/2.4-test-design-20250916.md (Quinn — 2025-09-16)
+- PO Validation: Pending — complete after workflow implementation review.
+
+## Change Log
+
+| Date       | Version | Description                | Author |
+| ---------- | ------- | -------------------------- | ------ |
+| 2025-09-16 | 0.1     | Initial draft of Story 2.4 | SM     |

--- a/docs/stories/2.5.developer-experience-documentation.md
+++ b/docs/stories/2.5.developer-experience-documentation.md
@@ -1,0 +1,64 @@
+# Story 2.5: Developer Experience Documentation
+
+Status: Draft
+
+## Story
+
+**As a** product owner onboarding new contributors,
+**I want** up-to-date documentation describing the lint, format, type check, and test workflow,
+**so that** developers can self-serve the baseline commands and avoid CI surprises.
+
+Dependencies: Stories 2.1–2.4 (tooling implemented and CI in place).
+
+## Acceptance Criteria
+
+1. `docs/validation.md` (or new `docs/testing.md`) includes sections covering Ruff (lint + format), Prettier, ty, and pytest commands with step-by-step instructions.
+2. README.md contains a quickstart snippet (<10 lines) summarizing the primary commands (`uvx ruff format`, `uvx ruff check`, `uv run ty check`, `uv run pytest --cov`).
+3. Documentation references GitHub issue #5 and links to workflow (`.github/workflows/ci.yml`) for deeper context.
+4. Onboarding checklist (if present in `onboarding-chatgpt.md` or similar) is updated to include running pre-commit hooks and the full validation suite.
+5. Docs reviewed by QA or PM; a confirmation comment is added to Issue #5 with links to updated sections.
+
+Evidence: Link to diff or published docs demonstrating updates; screenshot optional for onboarding doc.
+
+## Tasks / Subtasks
+
+- [ ] Update validation/testing docs
+  - [ ] Add or revise section covering command usage, expected outputs, and failure recovery tips.
+  - [ ] Include note on installing pre-commit hooks (`uvx pre-commit install`).
+- [ ] README quickstart
+  - [ ] Insert quickstart snippet; ensure `toc` unaffected.
+- [ ] Onboarding checklist update
+  - [ ] Modify `docs/onboarding-chatgpt.md` (or relevant doc) to include new tooling steps.
+- [ ] Cross-linking
+  - [ ] Add references to Issue #5 and `docs/issues/testing-tooling-baseline.md` if relocated.
+- [ ] Stakeholder review
+  - [ ] Request QA/PM sign-off and post confirmation comment in Issue #5.
+
+## Dev Notes
+
+- Keep command blocks short; prefer fenced code blocks with explanatory bullet list.
+- Include troubleshooting tips (e.g., clearing `~/.cache/uv` if sync fails).
+- Mention Node version requirement for Prettier (≥18) to mitigate OPS-205 risk.
+
+### References
+
+- Story Seed S5: docs/stories/SEED-epic-2-testing-foundations.md#s5--developer-experience-documentation
+- Existing docs: docs/validation.md, docs/onboarding-chatgpt.md, README.md
+- Issue #5: https://github.com/DrJLabs/mcp-farm/issues/5
+
+## Testing
+
+- Manual review: ensure commands copy/paste successfully on local environment.
+- Optional: run `markdownlint` or Prettier to confirm formatting.
+
+## QA Results
+
+- Risk Assessment: docs/qa/assessments/2.5-risk-20250916.md (Quinn — 2025-09-16)
+- Test Design: docs/qa/assessments/2.5-test-design-20250916.md (Quinn — 2025-09-16)
+- PO Validation: Pending — capture once documentation updated and reviewed.
+
+## Change Log
+
+| Date       | Version | Description                | Author |
+| ---------- | ------- | -------------------------- | ------ |
+| 2025-09-16 | 0.1     | Initial draft of Story 2.5 | SM     |

--- a/docs/stories/README.md
+++ b/docs/stories/README.md
@@ -1,4 +1,6 @@
-# Stories — Epic 1 Seeds
+# Stories
+
+## Epic 1 — OAuth-Secured Sample MCP
 
 Use these seeds to draft S1–S7 stories. Reference the listed shards for context and acceptance.
 
@@ -8,6 +10,20 @@ Use these seeds to draft S1–S7 stories. Reference the listed shards for contex
 - ADRs: docs/adr/README.md
 
 Story guidance
+
 - Keep each story scoped to one Sx
 - Link acceptance to Gate A–D as applicable
 - Attach curl/script outputs as evidence in PRs
+
+## Epic 2 — Testing & Tooling Baseline
+
+Use these seeds and drafted stories to roll out repo-wide tooling, coverage, and CI.
+
+- Seed Map: docs/stories/SEED-epic-2-testing-foundations.md
+- Issue Tracker: https://github.com/DrJLabs/mcp-farm/issues/5
+- Baseline Plan: docs/issues/testing-tooling-baseline.md (if relocated, update links)
+
+Story guidance
+
+- Ensure dependencies between S1–S5 (Ruff baseline → CI → documentation) remain explicit in each story.
+- Capture command outputs (Ruff, ty, pytest, CI runs) as evidence in PRs or Issue #5 comments.

--- a/docs/stories/SEED-epic-1-auth-streaming.md
+++ b/docs/stories/SEED-epic-1-auth-streaming.md
@@ -5,6 +5,7 @@ Purpose: Give the Scrum Master a precise map from PRD/Architecture shards to sto
 Note: File paths are workspace‑relative.
 
 ## S1 — Bootstrap env and healthcheck
+
 - Inputs:
   - docs/prd/epic-list.md
   - docs/architecture/observability-health.md
@@ -16,6 +17,7 @@ Note: File paths are workspace‑relative.
   - docs/validation.md (Health step) and curl output in commit/PR.
 
 ## S2 — Traefik routing + TLS labels
+
 - Inputs:
   - docs/prd/epic-list.md
   - docs/architecture/reference-deployment-docker-traefik-proposed.md
@@ -26,6 +28,7 @@ Note: File paths are workspace‑relative.
   - docs/validation.md (Health via Traefik) evidence.
 
 ## S3 — PRM + 401 hint
+
 - Inputs:
   - docs/prd/requirements.md (FR1–FR2)
   - docs/architecture/prm-shape-minimal-example-mvp.md
@@ -37,6 +40,7 @@ Note: File paths are workspace‑relative.
   - Curl outputs stored in PR/issue.
 
 ## S4 — OAuth 2.1 validation (JWKS, iss/aud)
+
 - Inputs:
   - docs/prd/requirements.md (FR3)
   - docs/architecture/security-controls.md
@@ -49,6 +53,7 @@ Note: File paths are workspace‑relative.
   - OIDC/JWKS curls; successful authenticated call (any minimal tool call OK).
 
 ## S5 — Streamable‑HTTP transport (preferred) + SSE fallback
+
 - Inputs:
   - docs/prd/requirements.md (FR4, FR8)
   - docs/architecture/performance-slos-mvp-targets.md
@@ -60,6 +65,7 @@ Note: File paths are workspace‑relative.
   - Stream smoke output in PR; note p95 TTFB < 2s or chunk cadence ≥ 10.
 
 ## S6 — RFC 8414 path‑insert shim
+
 - Inputs:
   - docs/prd/requirements.md (FR6)
   - docs/architecture/reference-deployment-docker-traefik-proposed.md
@@ -71,6 +77,7 @@ Note: File paths are workspace‑relative.
   - Curl outputs for both shimmed endpoints.
 
 ## S7 — ChatGPT Developer‑mode onboarding + validation scripts
+
 - Inputs:
   - docs/onboarding-chatgpt.md
   - scripts/validate_mvp.sh
@@ -81,12 +88,14 @@ Note: File paths are workspace‑relative.
   - Screenshot(s) and logs attached to PR/issue.
 
 ## Cross‑Cutting References
+
 - Out‑of‑Scope (guardrails): docs/prd/out-of-scope-mvp.md
 - SLOs & Perf: docs/architecture/performance-slos-mvp-targets.md
 - Security: docs/architecture/security-controls.md
 - ADRs (accepted): docs/adr/README.md
 
 ## Suggested Story Structure (per Sx)
+
 - Story: “Sx: <title>”
 - Acceptance Criteria: Gate reference + concrete curl/script outputs.
 - Tasks: update code/labels/envs; run validation; attach evidence.

--- a/docs/stories/SEED-epic-2-testing-foundations.md
+++ b/docs/stories/SEED-epic-2-testing-foundations.md
@@ -1,0 +1,108 @@
+# Story Seed — Epic 2: Testing & Tooling Baseline
+
+Purpose: Define the implementation roadmap that elevates linting, formatting, type checks, and automated tests to production-ready coverage. This epic flows from GitHub issue #5 and the testing/tooling plan.
+
+Note: File paths are workspace-relative unless noted.
+
+## Epic Objectives
+
+- Enforce Ruff lint + format across the entire monorepo using a shared configuration.
+- Extend automation to documentation assets (Markdown/JSON/YAML) via Prettier.
+- Raise automated test coverage for the sample MCP and supporting scripts with measurable coverage thresholds.
+- Introduce CI enforcement (uv, Ruff, ty, pytest --cov) so regressions are blocked before merge.
+- Document the new developer workflow, ensuring contributors can run the baseline locally.
+
+## Success Metrics
+
+- `uvx ruff check` and `uvx ruff format --check` pass cleanly on every push; Ruff config lives at repo root.
+- Pytest suite produces ≥80% line coverage and exercises sample MCP tool functions plus streaming smoke.
+- CI pipeline (GitHub Actions) fails on lint, format, type checking, or coverage regressions and uploads coverage artifacts.
+- Developer onboarding docs describe the lint/format/test commands and are referenced by at least one story handoff.
+
+## Backlog Seeds (Sx)
+
+### S1 — Repo-level Ruff & Prettier baseline
+
+- Inputs:
+  - docs/issues/testing-tooling-baseline.md
+  - fastmcp/.pre-commit-config.yaml
+  - fastmcp/pyproject.toml (tool.ruff, tool.ty)
+- Deliverables:
+  - Root `pyproject.toml` (or `.ruff.toml`) that scopes Ruff to `fastmcp/`, `tests/`, `sample-deep-research-mcp/`, `scripts/`.
+  - Repo-level `.pre-commit-config.yaml` running Ruff lint/format and Prettier (Markdown/JSON/YAML).
+- Gate T1 evidence:
+  - `uvx ruff check` and `uvx ruff format --check` succeed locally; Prettier dry-run shows no changes.
+
+### S2 — Harmonize package configs & type checks
+
+- Inputs:
+  - fastmcp/pyproject.toml (`tool.ty` and Ruff overrides)
+  - docs/issues/testing-tooling-baseline.md (Plan §2)
+- Deliverables:
+  - Duplicate Ruff settings removed or updated to inherit root config.
+  - `tool.ty.src.include` covers sample MCP and shared tests; ignored rules triaged or ticketed.
+- Gate T2 evidence:
+  - `uv run ty check` passes; documented list of remaining ignores with rationale in issue #5.
+
+### S3 — Unit and integration coverage expansion
+
+- Inputs:
+  - sample-deep-research-mcp/sample_mcp.py
+  - tests/
+  - scripts/stream_smoke.py
+  - docs/validation.md (smoke requirements)
+- Deliverables:
+  - Pytest unit tests for `search`/`fetch` tool paths and auth edge cases.
+  - Stream smoke script wrapped in pytest (mark `integration`).
+  - `pytest-cov` configured with ≥80% threshold; HTML/XML outputs stored under `tests/coverage/`.
+- Gate T3 evidence:
+  - `uv run pytest --cov` report meeting threshold; integration marks listed in `pytest --markers`.
+
+### S4 — CI workflow enforcement
+
+- Inputs:
+  - .github/workflows (new)
+  - docs/issues/testing-tooling-baseline.md (Plan §4)
+  - scripts/validate_mvp.sh
+- Deliverables:
+  - `.github/workflows/ci.yml` covering uv sync, Ruff lint, Ruff format check, ty check, pytest with coverage, artifact upload.
+  - Cache strategy for `~/.cache/uv` documented in workflow.
+- Gate T4 evidence:
+  - Successful CI run on feature branch; failure example when formatting intentionally broken (screenshots/log in PR).
+
+### S5 — Developer experience documentation
+
+- Inputs:
+  - docs/validation.md
+  - onboarding-chatgpt.md (structure reference)
+  - README.md (setup instructions)
+- Deliverables:
+  - Updated `docs/validation.md` (or new `docs/testing.md`) describing local commands for Ruff, Prettier, ty, pytest.
+  - Quickstart snippet added to README.md.
+- Gate T5 evidence:
+  - Documentation reviewed and linked from issue #5; onboarding checklist references new commands.
+
+## Dependencies & Risks
+
+- Requires GitHub Actions access in repo (confirm permissions).
+- Potential ty rule churn—schedule follow-up if ignored Diagnostics still exceed tolerances after S2.
+- Streaming smoke tests may need mock Keycloak tokens; coordinate with Dev to provide fixtures.
+
+## Related Work
+
+- GitHub Issue #5 “Harden testing and tooling baseline for MCP Farm”.
+- PRD Gates: supports FR8 and validation readiness checkpoints.
+- ADR 001 (Streamable HTTP) informs streaming smoke acceptance.
+
+## Acceptance Gates Summary
+
+- **Gate T1**: Ruff + Prettier automation proven locally.
+- **Gate T2**: Type checker spans shared modules and passes.
+- **Gate T3**: Coverage target met with new tests.
+- **Gate T4**: CI workflow blocks regressions; artifact uploaded.
+- **Gate T5**: Documentation updated for developers.
+
+## Handoff Notes
+
+- Once Gate T3 passes, QA can begin authoring risk-based test designs against the expanded suite.
+- Coordinate with Scrum Master to slice S1–S5 into sprint stories; ensure each story references this seed and issue #5.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,49 @@
+# Tooling & Testing Quickstart
+
+Use these commands before opening a PR to ensure code style and tests match the repo baseline.
+
+## 1. Install Pre-commit Hooks
+
+```bash
+uvx pre-commit install
+```
+
+This installs the repo-level hooks so Ruff and Prettier run automatically on staged files.
+
+## 2. Ruff Lint
+
+```bash
+uvx ruff check .
+```
+
+Runs the linter across `fastmcp/`, `tests/`, `sample-deep-research-mcp/`, and `scripts/` using the shared root configuration.
+
+## 3. Ruff Format
+
+```bash
+uvx ruff format --check .
+```
+
+Verifies formatting and import order without writing changes. To autofix, drop `--check`.
+
+## 4. Prettier Docs & Config Files
+
+```bash
+npx prettier --check '**/*.{md,mdx,json,yaml,yml}'
+```
+
+Ensures Markdown, JSON, and YAML assets stay consistent.
+
+## 5. Pytest Smoke
+
+```bash
+uv run pytest -q
+```
+
+Execute the current pytest suite. Stories may require deeper coverage—see QA assessments for scenario-level guidance.
+
+## Troubleshooting
+
+- If `npx` complains about Node, install Node 18+ or enable Corepack (`corepack enable`).
+- Clear caches with `rm -rf ~/.cache/uv` if dependency resolution stalls.
+- Re-run `uvx pre-commit install` after updating `.pre-commit-config.yaml`.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -3,6 +3,7 @@
 This guide validates the OAuth‑secured Sample MCP behind Traefik.
 
 Prereqs
+
 - DNS or `/etc/hosts` entries for `mcp.localhost` and `auth.localhost` → 127.0.0.1
 - `docker compose up -d` with `compose.yaml` from repo root
 - `.env` created from `.env.example`, issuer and URLs set
@@ -12,13 +13,15 @@ Prereqs
 ```bash
 curl -sS https://mcp.localhost/.well-known/oauth-protected-resource | jq
 ```
+
 Expect JSON with:
+
 - `resource: "https://mcp.localhost"`
 - `authorization_servers: ["https://auth.localhost/realms/mcp"]`
 
 ## 2) OIDC Discovery and JWKS (realm-first)
 
-```bash
+````bash
 curl -sS https://auth.localhost/realms/mcp/.well-known/openid-configuration | \
   jq '.issuer,.jwks_uri,.authorization_endpoint,.token_endpoint'
 
@@ -34,15 +37,18 @@ curl -sS https://auth.localhost/.well-known/openid-configuration | jq '.issuer,.
 
 # OAuth Authorization Server Metadata (RFC 8414) (shimmed)
 curl -sS https://auth.localhost/.well-known/oauth-authorization-server | jq '.issuer,.jwks_uri'
-```
-```
+````
+
+````
 
 ## 3) 401 with PRM hint (unauthenticated)
 
 ```bash
 curl -isk https://mcp.localhost/mcp | sed -n '1,20p'
-```
+````
+
 Expect:
+
 - `HTTP/2 401`
 - `WWW-Authenticate: Bearer resource_metadata="https://mcp.localhost/.well-known/oauth-protected-resource"`
 
@@ -51,6 +57,7 @@ Expect:
 ```bash
 curl -sS https://mcp.localhost/healthz | jq
 ```
+
 Expect: `{ "ok": true }`
 
 ## 5) Streamable‑HTTP Smoke (authenticated)
@@ -67,6 +74,7 @@ Expect a tools list, e.g. `{"tools":["search","fetch"]}`. This confirms an authe
 Streamable‑HTTP round‑trip via Traefik.
 
 Notes
+
 - If Streamable‑HTTP is unavailable in the FastMCP build, set `TRANSPORT=sse` and use
   an SSE client. For MVP we accept SSE as fallback while preferring Streamable‑HTTP.
 
@@ -77,12 +85,14 @@ Notes
 Purpose: verify `iss` and `aud` on a real token without exposing secrets in logs.
 
 Prereqs
+
 - A confidential service client with service accounts enabled (e.g., `mcp-smoke`) and a mapper adding your MCP audience to the access token.
 - Environment values in your private `.env` (not committed): `MCP_AUDIENCE`, `KC_ISSUER` (or `OIDC_ISSUER`).
 
 Steps (generic; replace hostnames as needed)
-1) Get an admin token for a service client (client credentials grant) and mint a service token for `mcp-smoke`.
-2) Decode token payload locally to inspect claims (do not print the token itself):
+
+1. Get an admin token for a service client (client credentials grant) and mint a service token for `mcp-smoke`.
+2. Decode token payload locally to inspect claims (do not print the token itself):
 
 ```bash
 ACCESS_TOKEN="<redacted>"
@@ -92,8 +102,10 @@ printf '%s' "$PAYLOAD" | base64 -d | jq '{iss,aud,azp,exp}'
 ```
 
 Expect
+
 - `iss` equals your realm issuer (e.g., `https://<auth-host>/auth/realms/<realm>`)
 - `aud` contains your MCP audience and any secondary audiences (e.g., client IDs)
 
 Notes
+
 - Keep audience strict: set primary to your MCP identifier (URL or a dedicated resource client) and optionally accept a secondary audience for compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.ruff]
+target-version = "py311"
+src = [
+  "fastmcp/src",
+  "tests",
+  "sample-deep-research-mcp",
+  "scripts",
+]
+
+[tool.ruff.lint]
+extend-select = ["I", "UP"]
+
+[tool.ruff.format]
+indent-style = "space"
+line-ending = "lf"
+

--- a/sample-deep-research-mcp/README.md
+++ b/sample-deep-research-mcp/README.md
@@ -20,6 +20,7 @@ python sample_mcp.py
 ```
 
 Endpoints:
+
 - Streamable‑HTTP: `http://127.0.0.1:8000/mcp`
 - Health: `http://127.0.0.1:8000/healthz`
 
@@ -30,6 +31,7 @@ TRANSPORT=sse python sample_mcp.py
 ```
 
 With OAuth (Keycloak): set envs per `.env.example` in repo root:
+
 - `MCP_SERVER_URL`, `KC_ISSUER`, optional `KC_JWKS_URI`
 - `MCP_AUDIENCE` and optional `MCP_ALT_AUDIENCE`
 

--- a/sample-deep-research-mcp/records.json
+++ b/sample-deep-research-mcp/records.json
@@ -3,300 +3,356 @@
     "id": "1",
     "title": "Alice order",
     "text": "Alice ordered a dozen vanilla cupcakes for Tuesday pickup.",
-    "metadata": {"customer": "Alice", "flavor": "vanilla", "quantity": "12"}
+    "metadata": { "customer": "Alice", "flavor": "vanilla", "quantity": "12" }
   },
   {
     "id": "2",
     "title": "Bob order",
     "text": "Bob requested six chocolate cupcakes delivered on Friday.",
-    "metadata": {"customer": "Bob", "flavor": "chocolate", "quantity": "6"}
+    "metadata": { "customer": "Bob", "flavor": "chocolate", "quantity": "6" }
   },
   {
     "id": "3",
     "title": "Carol order",
     "text": "Carol bought three red velvet cupcakes with cream cheese frosting.",
-    "metadata": {"customer": "Carol", "flavor": "red velvet", "quantity": "3"}
+    "metadata": { "customer": "Carol", "flavor": "red velvet", "quantity": "3" }
   },
   {
     "id": "4",
     "title": "Dave order",
     "text": "Dave picked up a dozen lemon cupcakes for his party.",
-    "metadata": {"customer": "Dave", "flavor": "lemon", "quantity": "12"}
+    "metadata": { "customer": "Dave", "flavor": "lemon", "quantity": "12" }
   },
   {
     "id": "5",
     "title": "Eve order",
     "text": "Eve ordered two dozen assorted cupcakes including vanilla and chocolate.",
-    "metadata": {"customer": "Eve", "flavors": "vanilla,chocolate", "quantity": "24"}
+    "metadata": {
+      "customer": "Eve",
+      "flavors": "vanilla,chocolate",
+      "quantity": "24"
+    }
   },
   {
     "id": "6",
     "title": "Frank order",
     "text": "Frank ordered 2 strawberry cupcakes for pickup.",
-    "metadata": {"customer": "Frank", "flavor": "strawberry", "quantity": "2"}
+    "metadata": { "customer": "Frank", "flavor": "strawberry", "quantity": "2" }
   },
   {
     "id": "7",
     "title": "Grace order",
     "text": "Grace ordered 4 chocolate cupcakes for pickup.",
-    "metadata": {"customer": "Grace", "flavor": "chocolate", "quantity": "4"}
+    "metadata": { "customer": "Grace", "flavor": "chocolate", "quantity": "4" }
   },
   {
     "id": "8",
     "title": "Heidi order",
     "text": "Heidi ordered 6 red velvet cupcakes for pickup.",
-    "metadata": {"customer": "Heidi", "flavor": "red velvet", "quantity": "6"}
+    "metadata": { "customer": "Heidi", "flavor": "red velvet", "quantity": "6" }
   },
   {
     "id": "9",
     "title": "Ivan order",
     "text": "Ivan ordered 8 lemon cupcakes for pickup.",
-    "metadata": {"customer": "Ivan", "flavor": "lemon", "quantity": "8"}
+    "metadata": { "customer": "Ivan", "flavor": "lemon", "quantity": "8" }
   },
   {
     "id": "10",
     "title": "Judy order",
     "text": "Judy ordered 10 vanilla cupcakes for pickup.",
-    "metadata": {"customer": "Judy", "flavor": "vanilla", "quantity": "10"}
+    "metadata": { "customer": "Judy", "flavor": "vanilla", "quantity": "10" }
   },
   {
     "id": "11",
     "title": "Karl order",
     "text": "Karl ordered 12 carrot cupcakes for pickup.",
-    "metadata": {"customer": "Karl", "flavor": "carrot", "quantity": "12"}
+    "metadata": { "customer": "Karl", "flavor": "carrot", "quantity": "12" }
   },
   {
     "id": "12",
     "title": "Leo order",
     "text": "Leo ordered 3 coconut cupcakes for pickup.",
-    "metadata": {"customer": "Leo", "flavor": "coconut", "quantity": "3"}
+    "metadata": { "customer": "Leo", "flavor": "coconut", "quantity": "3" }
   },
   {
     "id": "13",
     "title": "Mallory order",
     "text": "Mallory ordered 5 pistachio cupcakes for pickup.",
-    "metadata": {"customer": "Mallory", "flavor": "pistachio", "quantity": "5"}
+    "metadata": {
+      "customer": "Mallory",
+      "flavor": "pistachio",
+      "quantity": "5"
+    }
   },
   {
     "id": "14",
     "title": "Niaj order",
     "text": "Niaj ordered 7 marble cupcakes for pickup.",
-    "metadata": {"customer": "Niaj", "flavor": "marble", "quantity": "7"}
+    "metadata": { "customer": "Niaj", "flavor": "marble", "quantity": "7" }
   },
   {
     "id": "15",
     "title": "Olivia order",
     "text": "Olivia ordered 9 blueberry cupcakes for pickup.",
-    "metadata": {"customer": "Olivia", "flavor": "blueberry", "quantity": "9"}
+    "metadata": { "customer": "Olivia", "flavor": "blueberry", "quantity": "9" }
   },
   {
     "id": "16",
     "title": "Peggy order",
     "text": "Peggy ordered 11 pumpkin spice cupcakes for pickup.",
-    "metadata": {"customer": "Peggy", "flavor": "pumpkin spice", "quantity": "11"}
+    "metadata": {
+      "customer": "Peggy",
+      "flavor": "pumpkin spice",
+      "quantity": "11"
+    }
   },
   {
     "id": "17",
     "title": "Quentin order",
     "text": "Quentin ordered 13 funfetti cupcakes for pickup.",
-    "metadata": {"customer": "Quentin", "flavor": "funfetti", "quantity": "13"}
+    "metadata": {
+      "customer": "Quentin",
+      "flavor": "funfetti",
+      "quantity": "13"
+    }
   },
   {
     "id": "18",
     "title": "Rupert order",
     "text": "Rupert ordered 15 salted caramel cupcakes for pickup.",
-    "metadata": {"customer": "Rupert", "flavor": "salted caramel", "quantity": "15"}
+    "metadata": {
+      "customer": "Rupert",
+      "flavor": "salted caramel",
+      "quantity": "15"
+    }
   },
   {
     "id": "19",
     "title": "Sybil order",
     "text": "Sybil ordered 17 cookies and cream cupcakes for pickup.",
-    "metadata": {"customer": "Sybil", "flavor": "cookies and cream", "quantity": "17"}
+    "metadata": {
+      "customer": "Sybil",
+      "flavor": "cookies and cream",
+      "quantity": "17"
+    }
   },
   {
     "id": "20",
     "title": "Trent order",
     "text": "Trent ordered 19 matcha cupcakes for pickup.",
-    "metadata": {"customer": "Trent", "flavor": "matcha", "quantity": "19"}
+    "metadata": { "customer": "Trent", "flavor": "matcha", "quantity": "19" }
   },
   {
     "id": "21",
     "title": "Uma order",
     "text": "Uma ordered 2 strawberry cupcakes for pickup.",
-    "metadata": {"customer": "Uma", "flavor": "strawberry", "quantity": "2"}
+    "metadata": { "customer": "Uma", "flavor": "strawberry", "quantity": "2" }
   },
   {
     "id": "22",
     "title": "Victor order",
     "text": "Victor ordered 4 chocolate cupcakes for pickup.",
-    "metadata": {"customer": "Victor", "flavor": "chocolate", "quantity": "4"}
+    "metadata": { "customer": "Victor", "flavor": "chocolate", "quantity": "4" }
   },
   {
     "id": "23",
     "title": "Walter order",
     "text": "Walter ordered 6 red velvet cupcakes for pickup.",
-    "metadata": {"customer": "Walter", "flavor": "red velvet", "quantity": "6"}
+    "metadata": {
+      "customer": "Walter",
+      "flavor": "red velvet",
+      "quantity": "6"
+    }
   },
   {
     "id": "24",
     "title": "Xander order",
     "text": "Xander ordered 8 lemon cupcakes for pickup.",
-    "metadata": {"customer": "Xander", "flavor": "lemon", "quantity": "8"}
+    "metadata": { "customer": "Xander", "flavor": "lemon", "quantity": "8" }
   },
   {
     "id": "25",
     "title": "Yolanda order",
     "text": "Yolanda ordered 10 vanilla cupcakes for pickup.",
-    "metadata": {"customer": "Yolanda", "flavor": "vanilla", "quantity": "10"}
+    "metadata": { "customer": "Yolanda", "flavor": "vanilla", "quantity": "10" }
   },
   {
     "id": "26",
     "title": "Zach order",
     "text": "Zach ordered 12 carrot cupcakes for pickup.",
-    "metadata": {"customer": "Zach", "flavor": "carrot", "quantity": "12"}
+    "metadata": { "customer": "Zach", "flavor": "carrot", "quantity": "12" }
   },
   {
     "id": "27",
     "title": "Aaron order",
     "text": "Aaron ordered 3 coconut cupcakes for pickup.",
-    "metadata": {"customer": "Aaron", "flavor": "coconut", "quantity": "3"}
+    "metadata": { "customer": "Aaron", "flavor": "coconut", "quantity": "3" }
   },
   {
     "id": "28",
     "title": "Betty order",
     "text": "Betty ordered 5 pistachio cupcakes for pickup.",
-    "metadata": {"customer": "Betty", "flavor": "pistachio", "quantity": "5"}
+    "metadata": { "customer": "Betty", "flavor": "pistachio", "quantity": "5" }
   },
   {
     "id": "29",
     "title": "Carlos order",
     "text": "Carlos ordered 7 marble cupcakes for pickup.",
-    "metadata": {"customer": "Carlos", "flavor": "marble", "quantity": "7"}
+    "metadata": { "customer": "Carlos", "flavor": "marble", "quantity": "7" }
   },
   {
     "id": "30",
     "title": "Diana order",
     "text": "Diana ordered 9 blueberry cupcakes for pickup.",
-    "metadata": {"customer": "Diana", "flavor": "blueberry", "quantity": "9"}
+    "metadata": { "customer": "Diana", "flavor": "blueberry", "quantity": "9" }
   },
   {
     "id": "31",
     "title": "Edward order",
     "text": "Edward ordered 11 pumpkin spice cupcakes for pickup.",
-    "metadata": {"customer": "Edward", "flavor": "pumpkin spice", "quantity": "11"}
+    "metadata": {
+      "customer": "Edward",
+      "flavor": "pumpkin spice",
+      "quantity": "11"
+    }
   },
   {
     "id": "32",
     "title": "Fiona order",
     "text": "Fiona ordered 13 funfetti cupcakes for pickup.",
-    "metadata": {"customer": "Fiona", "flavor": "funfetti", "quantity": "13"}
+    "metadata": { "customer": "Fiona", "flavor": "funfetti", "quantity": "13" }
   },
   {
     "id": "33",
     "title": "George order",
     "text": "George ordered 15 salted caramel cupcakes for pickup.",
-    "metadata": {"customer": "George", "flavor": "salted caramel", "quantity": "15"}
+    "metadata": {
+      "customer": "George",
+      "flavor": "salted caramel",
+      "quantity": "15"
+    }
   },
   {
     "id": "34",
     "title": "Hannah order",
     "text": "Hannah ordered 17 cookies and cream cupcakes for pickup.",
-    "metadata": {"customer": "Hannah", "flavor": "cookies and cream", "quantity": "17"}
+    "metadata": {
+      "customer": "Hannah",
+      "flavor": "cookies and cream",
+      "quantity": "17"
+    }
   },
   {
     "id": "35",
     "title": "Ian order",
     "text": "Ian ordered 19 matcha cupcakes for pickup.",
-    "metadata": {"customer": "Ian", "flavor": "matcha", "quantity": "19"}
+    "metadata": { "customer": "Ian", "flavor": "matcha", "quantity": "19" }
   },
   {
     "id": "36",
     "title": "Jenna order",
     "text": "Jenna ordered 2 strawberry cupcakes for pickup.",
-    "metadata": {"customer": "Jenna", "flavor": "strawberry", "quantity": "2"}
+    "metadata": { "customer": "Jenna", "flavor": "strawberry", "quantity": "2" }
   },
   {
     "id": "37",
     "title": "Kevin order",
     "text": "Kevin ordered 4 chocolate cupcakes for pickup.",
-    "metadata": {"customer": "Kevin", "flavor": "chocolate", "quantity": "4"}
+    "metadata": { "customer": "Kevin", "flavor": "chocolate", "quantity": "4" }
   },
   {
     "id": "38",
     "title": "Lily order",
     "text": "Lily ordered 6 red velvet cupcakes for pickup.",
-    "metadata": {"customer": "Lily", "flavor": "red velvet", "quantity": "6"}
+    "metadata": { "customer": "Lily", "flavor": "red velvet", "quantity": "6" }
   },
   {
     "id": "39",
     "title": "Michael order",
     "text": "Michael ordered 8 lemon cupcakes for pickup.",
-    "metadata": {"customer": "Michael", "flavor": "lemon", "quantity": "8"}
+    "metadata": { "customer": "Michael", "flavor": "lemon", "quantity": "8" }
   },
   {
     "id": "40",
     "title": "Nora order",
     "text": "Nora ordered 10 vanilla cupcakes for pickup.",
-    "metadata": {"customer": "Nora", "flavor": "vanilla", "quantity": "10"}
+    "metadata": { "customer": "Nora", "flavor": "vanilla", "quantity": "10" }
   },
   {
     "id": "41",
     "title": "Oscar order",
     "text": "Oscar ordered 12 carrot cupcakes for pickup.",
-    "metadata": {"customer": "Oscar", "flavor": "carrot", "quantity": "12"}
+    "metadata": { "customer": "Oscar", "flavor": "carrot", "quantity": "12" }
   },
   {
     "id": "42",
     "title": "Paula order",
     "text": "Paula ordered 3 coconut cupcakes for pickup.",
-    "metadata": {"customer": "Paula", "flavor": "coconut", "quantity": "3"}
+    "metadata": { "customer": "Paula", "flavor": "coconut", "quantity": "3" }
   },
   {
     "id": "43",
     "title": "Quincy order",
     "text": "Quincy ordered 5 pistachio cupcakes for pickup.",
-    "metadata": {"customer": "Quincy", "flavor": "pistachio", "quantity": "5"}
+    "metadata": { "customer": "Quincy", "flavor": "pistachio", "quantity": "5" }
   },
   {
     "id": "44",
     "title": "Rachel order",
     "text": "Rachel ordered 7 marble cupcakes for pickup.",
-    "metadata": {"customer": "Rachel", "flavor": "marble", "quantity": "7"}
+    "metadata": { "customer": "Rachel", "flavor": "marble", "quantity": "7" }
   },
   {
     "id": "45",
     "title": "Sam order",
     "text": "Sam ordered 9 blueberry cupcakes for pickup.",
-    "metadata": {"customer": "Sam", "flavor": "blueberry", "quantity": "9"}
+    "metadata": { "customer": "Sam", "flavor": "blueberry", "quantity": "9" }
   },
   {
     "id": "46",
     "title": "Tina order",
     "text": "Tina ordered 11 pumpkin spice cupcakes for pickup.",
-    "metadata": {"customer": "Tina", "flavor": "pumpkin spice", "quantity": "11"}
+    "metadata": {
+      "customer": "Tina",
+      "flavor": "pumpkin spice",
+      "quantity": "11"
+    }
   },
   {
     "id": "47",
     "title": "Ulysses order",
     "text": "Ulysses ordered 13 funfetti cupcakes for pickup.",
-    "metadata": {"customer": "Ulysses", "flavor": "funfetti", "quantity": "13"}
+    "metadata": {
+      "customer": "Ulysses",
+      "flavor": "funfetti",
+      "quantity": "13"
+    }
   },
   {
     "id": "48",
     "title": "Vanessa order",
     "text": "Vanessa ordered 15 salted caramel cupcakes for pickup.",
-    "metadata": {"customer": "Vanessa", "flavor": "salted caramel", "quantity": "15"}
+    "metadata": {
+      "customer": "Vanessa",
+      "flavor": "salted caramel",
+      "quantity": "15"
+    }
   },
   {
     "id": "49",
     "title": "Wayne order",
     "text": "Wayne ordered 17 cookies and cream cupcakes for pickup.",
-    "metadata": {"customer": "Wayne", "flavor": "cookies and cream", "quantity": "17"}
+    "metadata": {
+      "customer": "Wayne",
+      "flavor": "cookies and cream",
+      "quantity": "17"
+    }
   },
   {
     "id": "50",
     "title": "Xenia order",
     "text": "Xenia ordered 19 matcha cupcakes for pickup.",
-    "metadata": {"customer": "Xenia", "flavor": "matcha", "quantity": "19"}
+    "metadata": { "customer": "Xenia", "flavor": "matcha", "quantity": "19" }
   }
 ]

--- a/sample-deep-research-mcp/sample_mcp.py
+++ b/sample-deep-research-mcp/sample_mcp.py
@@ -1,14 +1,16 @@
-import os
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from fastmcp.server import FastMCP
+
 # FastMCP auth import compatibility: fallback when module layout differs
 try:  # fastmcp >=2.5 may expose auth at fastmcp.auth
-    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider  # type: ignore
     from mcp.server.auth.routes import cors_middleware
     from starlette.routing import Route
+
+    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider  # type: ignore
 
     class CupcakeRemoteAuthProvider(RemoteAuthProvider):
         """Remote auth provider that keeps PRM metadata aligned with MCP_SERVER_URL."""
@@ -20,14 +22,17 @@ try:  # fastmcp >=2.5 may expose auth at fastmcp.auth
                 self._cupcake_resource_url = base_url_str.rstrip("/") or base_url_str
             super().__init__(*args, base_url=base_url, **kwargs)
 
-        def get_routes(self, mcp_path: str | None = None, mcp_endpoint: Any | None = None):  # type: ignore[override]
+        def get_routes(
+            self, mcp_path: str | None = None, mcp_endpoint: Any | None = None
+        ):  # type: ignore[override]
             routes = [
                 route
                 for route in super().get_routes(mcp_path, mcp_endpoint)
                 if not (
                     isinstance(route, Route)
                     # Filter the base provider's PRM route so we control cache headers.
-                    and getattr(route, "path", None) == "/.well-known/oauth-protected-resource"
+                    and getattr(route, "path", None)
+                    == "/.well-known/oauth-protected-resource"
                 )
             ]
             resource_value = self._cupcake_resource_url
@@ -44,7 +49,9 @@ try:  # fastmcp >=2.5 may expose auth at fastmcp.auth
                     if self.resource_name:
                         payload["resource_name"] = self.resource_name
                     if self.resource_documentation:
-                        payload["resource_documentation"] = str(self.resource_documentation)
+                        payload["resource_documentation"] = str(
+                            self.resource_documentation
+                        )
 
                     response = JSONResponse(payload)
                     response.headers["Cache-Control"] = "public, max-age=60"
@@ -67,6 +74,7 @@ try:  # fastmcp >=2.5 may expose auth at fastmcp.auth
 except ModuleNotFoundError:  # pragma: no cover
     try:
         from fastmcp.auth import JWTVerifier, RemoteAuthProvider  # type: ignore
+
         cors_middleware = None  # type: ignore
         Route = None  # type: ignore
         CupcakeRemoteAuthProvider = RemoteAuthProvider  # type: ignore
@@ -83,13 +91,16 @@ from starlette.responses import JSONResponse, Response
 RECORDS = json.loads(Path(__file__).with_name("records.json").read_text())
 LOOKUP = {r["id"]: r for r in RECORDS}
 
+
 class SearchResult(BaseModel):
     id: str
     title: str
     text: str
 
+
 class SearchResultPage(BaseModel):
     results: list[SearchResult]
+
 
 class FetchResult(BaseModel):
     id: str
@@ -97,6 +108,7 @@ class FetchResult(BaseModel):
     text: str
     url: str | None = None
     metadata: dict[str, str] | None = None
+
 
 def _env(name: str, default: str | None = None) -> str | None:
     v = os.environ.get(name)
@@ -125,7 +137,9 @@ def create_server() -> FastMCP:
     audience_alt = _env("MCP_ALT_AUDIENCE")
 
     if issuer and server_url and JWTVerifier and RemoteAuthProvider:
-        jwks_uri = _env("KC_JWKS_URI", issuer.rstrip("/") + "/protocol/openid-connect/certs")
+        jwks_uri = _env(
+            "KC_JWKS_URI", issuer.rstrip("/") + "/protocol/openid-connect/certs"
+        )
 
         audiences: list[str] | str
         if audience_alt:
@@ -141,7 +155,9 @@ def create_server() -> FastMCP:
             base_url=server_url,
         )
         provider_cls = (
-            CupcakeRemoteAuthProvider if CupcakeRemoteAuthProvider is not None else RemoteAuthProvider
+            CupcakeRemoteAuthProvider
+            if CupcakeRemoteAuthProvider is not None
+            else RemoteAuthProvider
         )
         mcp.auth = provider_cls(
             token_verifier=jwt,
@@ -169,7 +185,9 @@ def create_server() -> FastMCP:
             ).lower()
             if any(t in hay for t in toks):
                 results.append(
-                    SearchResult(id=r["id"], title=r.get("title", ""), text=r.get("text", ""))
+                    SearchResult(
+                        id=r["id"], title=r.get("title", ""), text=r.get("text", "")
+                    )
                 )
 
         # Return the Pydantic model (FastMCP will serialise it for us)

--- a/scripts/stream_smoke.py
+++ b/scripts/stream_smoke.py
@@ -10,6 +10,7 @@ Requires:
 
 import asyncio
 import os
+
 from fastmcp.client import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
@@ -27,4 +28,3 @@ async def main() -> None:
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -50,7 +50,9 @@ def build_test_app(*, enable_auth: bool, stream_path: str = "/mcp"):
         elif "auth_server_provider" in params:
             kwargs["auth_server_provider"] = auth_provider
         else:
-            raise RuntimeError("create_streamable_http_app has no supported auth parameter")
+            raise RuntimeError(
+                "create_streamable_http_app has no supported auth parameter"
+            )
 
     return create_streamable_http_app(**kwargs)
 

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pytest
 from starlette.testclient import TestClient
 
 from tests._utils import build_test_app

--- a/tests/test_prm_and_401.py
+++ b/tests/test_prm_and_401.py
@@ -30,7 +30,9 @@ def test_prm_route_returns_expected_payload():
         response = client.get("/.well-known/oauth-protected-resource")
         assert response.status_code == 200
         assert response.headers.get("cache-control") == "public, max-age=60"
-        assert response.headers.get("content-type", "").split(";")[0] == "application/json"
+        assert (
+            response.headers.get("content-type", "").split(";")[0] == "application/json"
+        )
         assert response.json() == {
             "resource": os.environ["MCP_SERVER_URL"],
             "authorization_servers": [os.environ["KC_ISSUER"]],


### PR DESCRIPTION
## Summary
- add root Ruff configuration covering fastmcp/src, tests, sample MCP, and scripts
- introduce repo-level pre-commit hooks for Ruff lint/format and Prettier 3.3.2
- document contributor workflow and reformat tracked docs to comply

## Testing
- uvx ruff check .
- uvx ruff format --check .
- npx prettier --check '**/*.{md,mdx,json,yaml,yml}'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a fetch tool endpoint with a new result model, complementing search.
- Documentation
  - Major expansions: PRD, architecture, onboarding for ChatGPT MCP, testing quickstart, validation, story seeds/specs, and QA assessments/gates.
  - Clarified OAuth/TLS/Traefik flows, JWT verification, and deployment guidance.
- Chores
  - Enabled repo-wide lint/format via pre-commit (Ruff, Prettier) and root Ruff config.
  - Updated Prettier ignore patterns.
- Tests
  - Added QA evidence docs and test design artifacts; minor test cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->